### PR TITLE
Use common.bool true and false

### DIFF
--- a/contracts/contracts/Multisig.cairo
+++ b/contracts/contracts/Multisig.cairo
@@ -3,9 +3,8 @@
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.math import assert_le, assert_lt
+from starkware.cairo.common.bool import TRUE, FALSE
 from starkware.starknet.common.syscalls import call_contract, get_caller_address
-
-from constants import FALSE, TRUE
 
 #
 # Events

--- a/contracts/contracts/constants.cairo
+++ b/contracts/contracts/constants.cairo
@@ -1,4 +1,0 @@
-%lang starknet
-
-const TRUE = 1
-const FALSE = 0


### PR DESCRIPTION
Removed custom definition of TRUE and FALSE and imports them from https://github.com/starkware-libs/cairo-lang/blob/master/src/starkware/cairo/common/bool.cairo