### PR TITLE
Use uniform event naming

### DIFF
--- a/contracts/contracts/Multisig.cairo
+++ b/contracts/contracts/Multisig.cairo
@@ -26,28 +26,28 @@ from util import assert_unique_elements
 # @param nonce: Transaction nonce
 # @param to: Target address
 @event
-func SubmitTransaction(signer : felt, nonce : felt, to : felt):
+func TransactionSubmitted(signer : felt, nonce : felt, to : felt):
 end
 
 # @dev Event emitted when a transaction has been confirmed by a signer
 # @param signer: Transaction confirmer
 # @param nonce: Transaction nonce
 @event
-func ConfirmTransaction(signer : felt, nonce : felt):
+func TransactionConfirmed(signer : felt, nonce : felt):
 end
 
 # @dev Event emitted when a transaction confirmation has been revoked by a signer
 # @param signer: Transaction confirmation revoker
 # @param nonce: Transaction nonce
 @event
-func RevokeConfirmation(signer : felt, nonce : felt):
+func ConfirmationRevoked(signer : felt, nonce : felt):
 end
 
 # @dev Event emitted when a transaction has been executed
 # @param executer: Transaction executer
 # @param nonce: Transaction nonce
 @event
-func ExecuteTransaction(executer : felt, nonce : felt):
+func TransactionExecuted(executer : felt, nonce : felt):
 end
 
 # @dev Event emitted when the multisig's signer array has been changed
@@ -427,7 +427,7 @@ func submit_transaction{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_
 
     # Emit event & update tx count
     let (caller) = get_caller_address()
-    SubmitTransaction.emit(signer=caller, nonce=nonce, to=to)
+    TransactionSubmitted.emit(signer=caller, nonce=nonce, to=to)
     _next_nonce.write(value=nonce + 1)
 
     return ()
@@ -450,7 +450,7 @@ func confirm_transaction{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range
     let (caller) = get_caller_address()
     _is_confirmed.write(nonce=nonce, signer=caller, value=TRUE)
 
-    ConfirmTransaction.emit(signer=caller, nonce=nonce)
+    TransactionConfirmed.emit(signer=caller, nonce=nonce)
     return ()
 end
 
@@ -471,7 +471,7 @@ func revoke_confirmation{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range
     let (caller) = get_caller_address()
     _is_confirmed.write(nonce=nonce, signer=caller, value=FALSE)
 
-    RevokeConfirmation.emit(signer=caller, nonce=nonce)
+    ConfirmationRevoked.emit(signer=caller, nonce=nonce)
     return ()
 end
 
@@ -496,7 +496,7 @@ func execute_transaction{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range
     # Mark as executed
     _transactions.write(nonce=nonce, field=Transaction.executed, value=TRUE)
     let (caller) = get_caller_address()
-    ExecuteTransaction.emit(executer=caller, nonce=nonce)
+    TransactionExecuted.emit(executer=caller, nonce=nonce)
 
     # Actually execute it
     let response = call_contract(

--- a/contracts/test/Multisig.test.ts
+++ b/contracts/test/Multisig.test.ts
@@ -34,7 +34,7 @@ describe("Multisig with single signer", function () {
   let publicKey: string;
 
   before(async function () {
-    starknet.devnet.restart();
+    //starknet.devnet.restart(); // disabled until https://github.com/Shard-Labs/starknet-devnet/issues/221 is fixed
 
     account = await starknet.deployAccount("OpenZeppelin");
     nonSigner = await starknet.deployAccount("OpenZeppelin");
@@ -699,9 +699,9 @@ describe("Multisig with single signer", function () {
         { data: ethers.utils.hexValue(0) },
       ];
 
-      assertEvent(receiptSubmit, "SubmitTransaction", eventDataSubmit);
-      assertEvent(receiptConfirm, "ConfirmTransaction", eventDataConfirm);
-      assertEvent(receiptExecute, "ExecuteTransaction", eventDataExecute);
+      assertEvent(receiptSubmit, "TransactionSubmitted", eventDataSubmit);
+      assertEvent(receiptConfirm, "TransactionConfirmed", eventDataConfirm);
+      assertEvent(receiptExecute, "TransactionExecuted", eventDataExecute);
     });
 
     it("correct events are emitted for revoke", async function () {
@@ -721,7 +721,7 @@ describe("Multisig with single signer", function () {
         { data: ethers.utils.hexValue(0) },
       ];
 
-      assertEvent(receipt, "RevokeConfirmation", eventData);
+      assertEvent(receipt, "ConfirmationRevoked", eventData);
     });
 
     it("correct events are emitted for signer change", async function () {
@@ -1167,7 +1167,7 @@ describe("Multisig with multiple signers", function () {
   let account3: Account;
 
   before(async function () {
-    starknet.devnet.restart();
+    //starknet.devnet.restart(); // disabled until https://github.com/Shard-Labs/starknet-devnet/issues/221 is fixed
 
     account1 = await starknet.deployAccount("OpenZeppelin");
     account2 = await starknet.deployAccount("OpenZeppelin");

--- a/frontend/public/Multisig.json
+++ b/frontend/public/Multisig.json
@@ -48,7 +48,7 @@
                 }
             ],
             "keys": [],
-            "name": "SubmitTransaction",
+            "name": "TransactionSubmitted",
             "type": "event"
         },
         {
@@ -63,7 +63,7 @@
                 }
             ],
             "keys": [],
-            "name": "ConfirmTransaction",
+            "name": "TransactionConfirmed",
             "type": "event"
         },
         {
@@ -78,7 +78,7 @@
                 }
             ],
             "keys": [],
-            "name": "RevokeConfirmation",
+            "name": "ConfirmationRevoked",
             "type": "event"
         },
         {
@@ -93,7 +93,7 @@
                 }
             ],
             "keys": [],
-            "name": "ExecuteTransaction",
+            "name": "TransactionExecuted",
             "type": "event"
         },
         {
@@ -1167,7 +1167,7 @@
             "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffe05",
             "0x40137fff7fff8000",
             "0x480680017fff8000",
-            "0x20deaeaaee2cafc4fa8af7b085aaf8e740a04b84bd28e7fb8a91d4bf9c4c2af",
+            "0x386645ea80103a018d64a0a70db7c72c018afb0a763c310fdd3165e9e5e6f51",
             "0x4002800080007fff",
             "0x1104800180018000",
             "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffdff",
@@ -1193,7 +1193,7 @@
             "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffdeb",
             "0x40137fff7fff8000",
             "0x480680017fff8000",
-            "0x285bed6c068e65d1b6e7b706969db1d98eb77a936e9b05162633667fbd83da0",
+            "0x4a6259fe7cb9bd6814bc8669d020c188753d849e2b4917e6f6249c8f49d58d",
             "0x4002800080007fff",
             "0x1104800180018000",
             "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffde5",
@@ -1218,7 +1218,7 @@
             "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffdd2",
             "0x40137fff7fff8000",
             "0x480680017fff8000",
-            "0x278ebb988d1f4449c7c7f2fbf948159a18ad6cdb8e21018a2a0b16b625d971b",
+            "0xe243a5b518aef1d0fa715706afab00267bd034c70dcad2d16b011c20a4b43b",
             "0x4002800080007fff",
             "0x1104800180018000",
             "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffdcc",
@@ -1243,7 +1243,7 @@
             "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffdb9",
             "0x40137fff7fff8000",
             "0x480680017fff8000",
-            "0x3489f996376ed18a689a093e9c70570e21850fce2afa87e57102e6c9f5cbf4a",
+            "0x1dcde06aabdbca2f80aa51392b345d7549d7757aa855f7e37f5d335ac8243b1",
             "0x4002800080007fff",
             "0x1104800180018000",
             "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffdb3",
@@ -2911,24 +2911,24 @@
                 "autogen/starknet/arg_processor/dddef5deb48d77c2b777f7818c119d55373dc859a9d96120cc0b9b9d770eaaa8.cairo": "assert [__return_value_ptr] = ret_value.response_len\nlet __return_value_ptr = __return_value_ptr + 1\n",
                 "autogen/starknet/arg_processor/f3ea60531fda419d2c1917380b5b86465e39d0a2cca45fc716c484e7b3a124bd.cairo": "let __calldata_arg_address = [__calldata_ptr]\nlet __calldata_ptr = __calldata_ptr + 1\n",
                 "autogen/starknet/arg_processor/f63f9d624793c09feeaa452a88806d349beb82ecded482600b21cb375ff7014c.cairo": "assert [__calldata_ptr] = executer\nlet __calldata_ptr = __calldata_ptr + 1\n",
-                "autogen/starknet/event/ConfirmTransaction/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo": "func emit{syscall_ptr : felt*, range_check_ptr}():\nend\n",
-                "autogen/starknet/event/ConfirmTransaction/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo": "alloc_locals\nlet (local __keys_ptr : felt*) = alloc()\nassert [__keys_ptr] = SELECTOR\nlet (local __data_ptr : felt*) = alloc()\nlet __calldata_ptr = __data_ptr\n",
-                "autogen/starknet/event/ConfirmTransaction/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo": "emit_event(keys_len=1, keys=__keys_ptr, data_len=__calldata_ptr - __data_ptr, data=__data_ptr)\nreturn ()\n",
-                "autogen/starknet/event/ExecuteTransaction/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo": "func emit{syscall_ptr : felt*, range_check_ptr}():\nend\n",
-                "autogen/starknet/event/ExecuteTransaction/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo": "alloc_locals\nlet (local __keys_ptr : felt*) = alloc()\nassert [__keys_ptr] = SELECTOR\nlet (local __data_ptr : felt*) = alloc()\nlet __calldata_ptr = __data_ptr\n",
-                "autogen/starknet/event/ExecuteTransaction/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo": "emit_event(keys_len=1, keys=__keys_ptr, data_len=__calldata_ptr - __data_ptr, data=__data_ptr)\nreturn ()\n",
-                "autogen/starknet/event/RevokeConfirmation/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo": "func emit{syscall_ptr : felt*, range_check_ptr}():\nend\n",
-                "autogen/starknet/event/RevokeConfirmation/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo": "alloc_locals\nlet (local __keys_ptr : felt*) = alloc()\nassert [__keys_ptr] = SELECTOR\nlet (local __data_ptr : felt*) = alloc()\nlet __calldata_ptr = __data_ptr\n",
-                "autogen/starknet/event/RevokeConfirmation/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo": "emit_event(keys_len=1, keys=__keys_ptr, data_len=__calldata_ptr - __data_ptr, data=__data_ptr)\nreturn ()\n",
+                "autogen/starknet/event/ConfirmationRevoked/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo": "func emit{syscall_ptr : felt*, range_check_ptr}():\nend\n",
+                "autogen/starknet/event/ConfirmationRevoked/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo": "alloc_locals\nlet (local __keys_ptr : felt*) = alloc()\nassert [__keys_ptr] = SELECTOR\nlet (local __data_ptr : felt*) = alloc()\nlet __calldata_ptr = __data_ptr\n",
+                "autogen/starknet/event/ConfirmationRevoked/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo": "emit_event(keys_len=1, keys=__keys_ptr, data_len=__calldata_ptr - __data_ptr, data=__data_ptr)\nreturn ()\n",
                 "autogen/starknet/event/SignersSet/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo": "func emit{syscall_ptr : felt*, range_check_ptr}():\nend\n",
                 "autogen/starknet/event/SignersSet/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo": "alloc_locals\nlet (local __keys_ptr : felt*) = alloc()\nassert [__keys_ptr] = SELECTOR\nlet (local __data_ptr : felt*) = alloc()\nlet __calldata_ptr = __data_ptr\n",
                 "autogen/starknet/event/SignersSet/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo": "emit_event(keys_len=1, keys=__keys_ptr, data_len=__calldata_ptr - __data_ptr, data=__data_ptr)\nreturn ()\n",
-                "autogen/starknet/event/SubmitTransaction/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo": "func emit{syscall_ptr : felt*, range_check_ptr}():\nend\n",
-                "autogen/starknet/event/SubmitTransaction/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo": "alloc_locals\nlet (local __keys_ptr : felt*) = alloc()\nassert [__keys_ptr] = SELECTOR\nlet (local __data_ptr : felt*) = alloc()\nlet __calldata_ptr = __data_ptr\n",
-                "autogen/starknet/event/SubmitTransaction/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo": "emit_event(keys_len=1, keys=__keys_ptr, data_len=__calldata_ptr - __data_ptr, data=__data_ptr)\nreturn ()\n",
                 "autogen/starknet/event/ThresholdSet/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo": "func emit{syscall_ptr : felt*, range_check_ptr}():\nend\n",
                 "autogen/starknet/event/ThresholdSet/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo": "alloc_locals\nlet (local __keys_ptr : felt*) = alloc()\nassert [__keys_ptr] = SELECTOR\nlet (local __data_ptr : felt*) = alloc()\nlet __calldata_ptr = __data_ptr\n",
                 "autogen/starknet/event/ThresholdSet/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo": "emit_event(keys_len=1, keys=__keys_ptr, data_len=__calldata_ptr - __data_ptr, data=__data_ptr)\nreturn ()\n",
+                "autogen/starknet/event/TransactionConfirmed/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo": "func emit{syscall_ptr : felt*, range_check_ptr}():\nend\n",
+                "autogen/starknet/event/TransactionConfirmed/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo": "alloc_locals\nlet (local __keys_ptr : felt*) = alloc()\nassert [__keys_ptr] = SELECTOR\nlet (local __data_ptr : felt*) = alloc()\nlet __calldata_ptr = __data_ptr\n",
+                "autogen/starknet/event/TransactionConfirmed/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo": "emit_event(keys_len=1, keys=__keys_ptr, data_len=__calldata_ptr - __data_ptr, data=__data_ptr)\nreturn ()\n",
+                "autogen/starknet/event/TransactionExecuted/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo": "func emit{syscall_ptr : felt*, range_check_ptr}():\nend\n",
+                "autogen/starknet/event/TransactionExecuted/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo": "alloc_locals\nlet (local __keys_ptr : felt*) = alloc()\nassert [__keys_ptr] = SELECTOR\nlet (local __data_ptr : felt*) = alloc()\nlet __calldata_ptr = __data_ptr\n",
+                "autogen/starknet/event/TransactionExecuted/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo": "emit_event(keys_len=1, keys=__keys_ptr, data_len=__calldata_ptr - __data_ptr, data=__data_ptr)\nreturn ()\n",
+                "autogen/starknet/event/TransactionSubmitted/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo": "func emit{syscall_ptr : felt*, range_check_ptr}():\nend\n",
+                "autogen/starknet/event/TransactionSubmitted/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo": "alloc_locals\nlet (local __keys_ptr : felt*) = alloc()\nassert [__keys_ptr] = SELECTOR\nlet (local __data_ptr : felt*) = alloc()\nlet __calldata_ptr = __data_ptr\n",
+                "autogen/starknet/event/TransactionSubmitted/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo": "emit_event(keys_len=1, keys=__keys_ptr, data_len=__calldata_ptr - __data_ptr, data=__data_ptr)\nreturn ()\n",
                 "autogen/starknet/external/confirm_transaction/424b26e79f70343cc02557f1fbd25745138efb26a3dc5c8b593ca765b73138b7.cairo": "let pedersen_ptr = [cast([cast(fp + (-5), felt**)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]\n",
                 "autogen/starknet/external/confirm_transaction/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo": "return (syscall_ptr,pedersen_ptr,range_check_ptr,retdata_size,retdata)\n",
                 "autogen/starknet/external/confirm_transaction/c7060df96cb0acca1380ae43bf758cab727bfdf73cb5d34a93e24a9742817fda.cairo": "let syscall_ptr = [cast([cast(fp + (-5), felt**)] + 0, felt**)]\n",
@@ -7130,12 +7130,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 90,
-                        "end_line": 196,
+                        "end_line": 198,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 63,
-                        "start_line": 196
+                        "start_line": 198
                     }
                 },
                 "228": {
@@ -7147,12 +7147,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 91,
-                        "end_line": 196,
+                        "end_line": 198,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 196
+                        "start_line": 198
                     }
                 },
                 "229": {
@@ -7165,48 +7165,48 @@
                         {
                             "location": {
                                 "end_col": 93,
-                                "end_line": 197,
+                                "end_line": 199,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
                                 "start_col": 5,
-                                "start_line": 197
+                                "start_line": 199
                             },
                             "n_prefix_newlines": 0
                         }
                     ],
                     "inst": {
                         "end_col": 58,
-                        "end_line": 198,
+                        "end_line": 200,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 44,
-                                "end_line": 194,
+                                "end_line": 196,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 60,
-                                        "end_line": 199,
+                                        "end_line": 201,
                                         "input_file": {
                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                         },
                                         "start_col": 5,
-                                        "start_line": 199
+                                        "start_line": 201
                                     },
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 25,
-                                "start_line": 194
+                                "start_line": 196
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
                         "start_col": 23,
-                        "start_line": 198
+                        "start_line": 200
                     }
                 },
                 "231": {
@@ -7218,12 +7218,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 59,
-                        "end_line": 199,
+                        "end_line": 201,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 28,
-                        "start_line": 199
+                        "start_line": 201
                     }
                 },
                 "232": {
@@ -7235,12 +7235,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 60,
-                        "end_line": 199,
+                        "end_line": 201,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 199
+                        "start_line": 201
                     }
                 },
                 "233": {
@@ -7252,12 +7252,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 94,
-                        "end_line": 270,
+                        "end_line": 272,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 65,
-                        "start_line": 270
+                        "start_line": 272
                     }
                 },
                 "235": {
@@ -7269,12 +7269,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 95,
-                        "end_line": 270,
+                        "end_line": 272,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 270
+                        "start_line": 272
                     }
                 },
                 "236": {
@@ -7287,48 +7287,48 @@
                         {
                             "location": {
                                 "end_col": 95,
-                                "end_line": 271,
+                                "end_line": 273,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
                                 "start_col": 5,
-                                "start_line": 271
+                                "start_line": 273
                             },
                             "n_prefix_newlines": 0
                         }
                     ],
                     "inst": {
                         "end_col": 60,
-                        "end_line": 272,
+                        "end_line": 274,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 46,
-                                "end_line": 268,
+                                "end_line": 270,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 64,
-                                        "end_line": 273,
+                                        "end_line": 275,
                                         "input_file": {
                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                         },
                                         "start_col": 5,
-                                        "start_line": 273
+                                        "start_line": 275
                                     },
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 27,
-                                "start_line": 268
+                                "start_line": 270
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
                         "start_col": 23,
-                        "start_line": 272
+                        "start_line": 274
                     }
                 },
                 "238": {
@@ -7340,12 +7340,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 63,
-                        "end_line": 273,
+                        "end_line": 275,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 30,
-                        "start_line": 273
+                        "start_line": 275
                     }
                 },
                 "239": {
@@ -7357,12 +7357,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 64,
-                        "end_line": 273,
+                        "end_line": 275,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 273
+                        "start_line": 275
                     }
                 },
                 "240": {
@@ -7374,12 +7374,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 79,
-                        "end_line": 348,
+                        "end_line": 350,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 58,
-                        "start_line": 348
+                        "start_line": 350
                     }
                 },
                 "242": {
@@ -7391,12 +7391,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 97,
-                        "end_line": 348,
+                        "end_line": 350,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 348
+                        "start_line": 350
                     }
                 },
                 "243": {
@@ -7408,12 +7408,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 97,
-                        "end_line": 348,
+                        "end_line": 350,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 348
+                        "start_line": 350
                     }
                 },
                 "244": {
@@ -7426,48 +7426,48 @@
                         {
                             "location": {
                                 "end_col": 87,
-                                "end_line": 349,
+                                "end_line": 351,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
                                 "start_col": 5,
-                                "start_line": 349
+                                "start_line": 351
                             },
                             "n_prefix_newlines": 0
                         }
                     ],
                     "inst": {
                         "end_col": 53,
-                        "end_line": 351,
+                        "end_line": 353,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 38,
-                                "end_line": 346,
+                                "end_line": 348,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 34,
-                                        "end_line": 352,
+                                        "end_line": 354,
                                         "input_file": {
                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                         },
                                         "start_col": 5,
-                                        "start_line": 352
+                                        "start_line": 354
                                     },
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 19,
-                                "start_line": 346
+                                "start_line": 348
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
                         "start_col": 23,
-                        "start_line": 351
+                        "start_line": 353
                     }
                 },
                 "246": {
@@ -7479,12 +7479,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 33,
-                        "end_line": 352,
+                        "end_line": 354,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 19,
-                        "start_line": 352
+                        "start_line": 354
                     }
                 },
                 "247": {
@@ -7496,12 +7496,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 34,
-                        "end_line": 352,
+                        "end_line": 354,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 352
+                        "start_line": 354
                     }
                 },
                 "248": {
@@ -7513,12 +7513,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 40,
-                        "end_line": 366,
+                        "end_line": 368,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 18,
-                        "start_line": 366
+                        "start_line": 368
                     }
                 },
                 "250": {
@@ -7530,12 +7530,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 71,
-                        "end_line": 366,
+                        "end_line": 368,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 365
+                        "start_line": 367
                     }
                 },
                 "251": {
@@ -7547,12 +7547,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 71,
-                        "end_line": 366,
+                        "end_line": 368,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 365
+                        "start_line": 367
                     }
                 },
                 "252": {
@@ -7564,12 +7564,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 71,
-                        "end_line": 366,
+                        "end_line": 368,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 365
+                        "start_line": 367
                     }
                 },
                 "253": {
@@ -7582,48 +7582,48 @@
                         {
                             "location": {
                                 "end_col": 88,
-                                "end_line": 367,
+                                "end_line": 369,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
                                 "start_col": 5,
-                                "start_line": 367
+                                "start_line": 369
                             },
                             "n_prefix_newlines": 0
                         }
                     ],
                     "inst": {
                         "end_col": 54,
-                        "end_line": 368,
+                        "end_line": 370,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 39,
-                                "end_line": 364,
+                                "end_line": 366,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 14,
-                                        "end_line": 369,
+                                        "end_line": 371,
                                         "input_file": {
                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                         },
                                         "start_col": 5,
-                                        "start_line": 369
+                                        "start_line": 371
                                     },
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 20,
-                                "start_line": 364
+                                "start_line": 366
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
                         "start_col": 23,
-                        "start_line": 368
+                        "start_line": 370
                     }
                 },
                 "255": {
@@ -7635,12 +7635,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 14,
-                        "end_line": 369,
+                        "end_line": 371,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 369
+                        "start_line": 371
                     }
                 },
                 "256": {
@@ -7652,12 +7652,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 37,
-                        "end_line": 385,
+                        "end_line": 387,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 18,
-                        "start_line": 385
+                        "start_line": 387
                     }
                 },
                 "258": {
@@ -7669,12 +7669,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 98,
-                        "end_line": 385,
+                        "end_line": 387,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 384
+                        "start_line": 386
                     }
                 },
                 "259": {
@@ -7686,12 +7686,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 98,
-                        "end_line": 385,
+                        "end_line": 387,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 384
+                        "start_line": 386
                     }
                 },
                 "260": {
@@ -7703,12 +7703,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 98,
-                        "end_line": 385,
+                        "end_line": 387,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 384
+                        "start_line": 386
                     }
                 },
                 "261": {
@@ -7720,12 +7720,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 98,
-                        "end_line": 385,
+                        "end_line": 387,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 384
+                        "start_line": 386
                     }
                 },
                 "262": {
@@ -7737,12 +7737,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 98,
-                        "end_line": 385,
+                        "end_line": 387,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 384
+                        "start_line": 386
                     }
                 },
                 "263": {
@@ -7755,48 +7755,48 @@
                         {
                             "location": {
                                 "end_col": 85,
-                                "end_line": 386,
+                                "end_line": 388,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
                                 "start_col": 5,
-                                "start_line": 386
+                                "start_line": 388
                             },
                             "n_prefix_newlines": 0
                         }
                     ],
                     "inst": {
                         "end_col": 51,
-                        "end_line": 387,
+                        "end_line": 389,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 36,
-                                "end_line": 383,
+                                "end_line": 385,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 14,
-                                        "end_line": 388,
+                                        "end_line": 390,
                                         "input_file": {
                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                         },
                                         "start_col": 5,
-                                        "start_line": 388
+                                        "start_line": 390
                                     },
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 17,
-                                "start_line": 383
+                                "start_line": 385
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
                         "start_col": 23,
-                        "start_line": 387
+                        "start_line": 389
                     }
                 },
                 "265": {
@@ -7808,12 +7808,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 14,
-                        "end_line": 388,
+                        "end_line": 390,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 388
+                        "start_line": 390
                     }
                 },
                 "266": {
@@ -12038,8 +12038,8 @@
                 "506": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.SubmitTransaction",
-                        "__main__.SubmitTransaction.emit"
+                        "__main__.TransactionSubmitted",
+                        "__main__.TransactionSubmitted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -12047,11 +12047,11 @@
                         "end_col": 13,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/SubmitTransaction/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/TransactionSubmitted/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 23,
+                                "end_col": 26,
                                 "end_line": 29,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -12068,8 +12068,8 @@
                 "508": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.SubmitTransaction",
-                        "__main__.SubmitTransaction.emit"
+                        "__main__.TransactionSubmitted",
+                        "__main__.TransactionSubmitted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -12077,11 +12077,11 @@
                         "end_col": 41,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/event/SubmitTransaction/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/TransactionSubmitted/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 23,
+                                "end_col": 26,
                                 "end_line": 29,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -12098,8 +12098,8 @@
                 "510": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.SubmitTransaction",
-                        "__main__.SubmitTransaction.emit"
+                        "__main__.TransactionSubmitted",
+                        "__main__.TransactionSubmitted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -12107,11 +12107,11 @@
                         "end_col": 30,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/event/SubmitTransaction/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/TransactionSubmitted/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 23,
+                                "end_col": 26,
                                 "end_line": 29,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -12128,8 +12128,8 @@
                 "511": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.SubmitTransaction",
-                        "__main__.SubmitTransaction.emit"
+                        "__main__.TransactionSubmitted",
+                        "__main__.TransactionSubmitted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -12137,11 +12137,11 @@
                         "end_col": 31,
                         "end_line": 3,
                         "input_file": {
-                            "filename": "autogen/starknet/event/SubmitTransaction/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/TransactionSubmitted/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 23,
+                                "end_col": 26,
                                 "end_line": 29,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -12158,8 +12158,8 @@
                 "513": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.SubmitTransaction",
-                        "__main__.SubmitTransaction.emit"
+                        "__main__.TransactionSubmitted",
+                        "__main__.TransactionSubmitted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -12167,11 +12167,11 @@
                         "end_col": 31,
                         "end_line": 3,
                         "input_file": {
-                            "filename": "autogen/starknet/event/SubmitTransaction/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/TransactionSubmitted/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 23,
+                                "end_col": 26,
                                 "end_line": 29,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -12188,8 +12188,8 @@
                 "514": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.SubmitTransaction",
-                        "__main__.SubmitTransaction.emit"
+                        "__main__.TransactionSubmitted",
+                        "__main__.TransactionSubmitted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -12197,11 +12197,11 @@
                         "end_col": 41,
                         "end_line": 4,
                         "input_file": {
-                            "filename": "autogen/starknet/event/SubmitTransaction/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/TransactionSubmitted/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 23,
+                                "end_col": 26,
                                 "end_line": 29,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -12218,8 +12218,8 @@
                 "516": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.SubmitTransaction",
-                        "__main__.SubmitTransaction.emit"
+                        "__main__.TransactionSubmitted",
+                        "__main__.TransactionSubmitted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -12227,11 +12227,11 @@
                         "end_col": 30,
                         "end_line": 4,
                         "input_file": {
-                            "filename": "autogen/starknet/event/SubmitTransaction/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/TransactionSubmitted/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 23,
+                                "end_col": 26,
                                 "end_line": 29,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -12248,8 +12248,8 @@
                 "517": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.SubmitTransaction",
-                        "__main__.SubmitTransaction.emit"
+                        "__main__.TransactionSubmitted",
+                        "__main__.TransactionSubmitted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -12261,12 +12261,12 @@
                         },
                         "parent_location": [
                             {
-                                "end_col": 30,
+                                "end_col": 33,
                                 "end_line": 29,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
                                 },
-                                "start_col": 24,
+                                "start_col": 27,
                                 "start_line": 29
                             },
                             "While handling calldata argument 'signer'"
@@ -12278,8 +12278,8 @@
                 "518": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.SubmitTransaction",
-                        "__main__.SubmitTransaction.emit"
+                        "__main__.TransactionSubmitted",
+                        "__main__.TransactionSubmitted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -12291,12 +12291,12 @@
                         },
                         "parent_location": [
                             {
-                                "end_col": 44,
+                                "end_col": 47,
                                 "end_line": 29,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
                                 },
-                                "start_col": 39,
+                                "start_col": 42,
                                 "start_line": 29
                             },
                             "While handling calldata argument 'nonce'"
@@ -12308,8 +12308,8 @@
                 "519": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.SubmitTransaction",
-                        "__main__.SubmitTransaction.emit"
+                        "__main__.TransactionSubmitted",
+                        "__main__.TransactionSubmitted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -12321,12 +12321,12 @@
                         },
                         "parent_location": [
                             {
-                                "end_col": 55,
+                                "end_col": 58,
                                 "end_line": 29,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
                                 },
-                                "start_col": 53,
+                                "start_col": 56,
                                 "start_line": 29
                             },
                             "While handling calldata argument 'to'"
@@ -12338,8 +12338,8 @@
                 "520": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.SubmitTransaction",
-                        "__main__.SubmitTransaction.emit"
+                        "__main__.TransactionSubmitted",
+                        "__main__.TransactionSubmitted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -12351,7 +12351,7 @@
                         },
                         "parent_location": [
                             {
-                                "end_col": 55,
+                                "end_col": 58,
                                 "end_line": 29,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -12361,11 +12361,11 @@
                                         "end_col": 64,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/event/SubmitTransaction/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                                            "filename": "autogen/starknet/event/TransactionSubmitted/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 23,
+                                                "end_col": 26,
                                                 "end_line": 29,
                                                 "input_file": {
                                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -12380,7 +12380,7 @@
                                     },
                                     "While expanding the reference '__calldata_ptr' in:"
                                 ],
-                                "start_col": 53,
+                                "start_col": 56,
                                 "start_line": 29
                             },
                             "While handling calldata argument 'to'"
@@ -12392,8 +12392,8 @@
                 "522": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.SubmitTransaction",
-                        "__main__.SubmitTransaction.emit"
+                        "__main__.TransactionSubmitted",
+                        "__main__.TransactionSubmitted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -12401,11 +12401,11 @@
                         "end_col": 30,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/SubmitTransaction/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                            "filename": "autogen/starknet/event/TransactionSubmitted/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 23,
+                                "end_col": 26,
                                 "end_line": 29,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -12413,7 +12413,7 @@
                                 "parent_location": [
                                     {
                                         "end_col": 36,
-                                        "end_line": 383,
+                                        "end_line": 385,
                                         "input_file": {
                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                         },
@@ -12422,11 +12422,11 @@
                                                 "end_col": 95,
                                                 "end_line": 1,
                                                 "input_file": {
-                                                    "filename": "autogen/starknet/event/SubmitTransaction/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                                                    "filename": "autogen/starknet/event/TransactionSubmitted/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                                                 },
                                                 "parent_location": [
                                                     {
-                                                        "end_col": 23,
+                                                        "end_col": 26,
                                                         "end_line": 29,
                                                         "input_file": {
                                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -12442,7 +12442,7 @@
                                             "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                         ],
                                         "start_col": 17,
-                                        "start_line": 383
+                                        "start_line": 385
                                     },
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
@@ -12458,8 +12458,8 @@
                 "523": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.SubmitTransaction",
-                        "__main__.SubmitTransaction.emit"
+                        "__main__.TransactionSubmitted",
+                        "__main__.TransactionSubmitted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -12467,11 +12467,11 @@
                         "end_col": 22,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/SubmitTransaction/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                            "filename": "autogen/starknet/event/TransactionSubmitted/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 23,
+                                "end_col": 26,
                                 "end_line": 29,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -12488,8 +12488,8 @@
                 "525": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.SubmitTransaction",
-                        "__main__.SubmitTransaction.emit"
+                        "__main__.TransactionSubmitted",
+                        "__main__.TransactionSubmitted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -12497,11 +12497,11 @@
                         "end_col": 22,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/event/SubmitTransaction/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/TransactionSubmitted/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 23,
+                                "end_col": 26,
                                 "end_line": 29,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -12511,11 +12511,11 @@
                                         "end_col": 39,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/event/SubmitTransaction/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                                            "filename": "autogen/starknet/event/TransactionSubmitted/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 23,
+                                                "end_col": 26,
                                                 "end_line": 29,
                                                 "input_file": {
                                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -12542,8 +12542,8 @@
                 "526": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.SubmitTransaction",
-                        "__main__.SubmitTransaction.emit"
+                        "__main__.TransactionSubmitted",
+                        "__main__.TransactionSubmitted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -12551,11 +12551,11 @@
                         "end_col": 77,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/SubmitTransaction/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                            "filename": "autogen/starknet/event/TransactionSubmitted/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 23,
+                                "end_col": 26,
                                 "end_line": 29,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -12572,8 +12572,8 @@
                 "527": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.SubmitTransaction",
-                        "__main__.SubmitTransaction.emit"
+                        "__main__.TransactionSubmitted",
+                        "__main__.TransactionSubmitted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -12581,11 +12581,11 @@
                         "end_col": 22,
                         "end_line": 4,
                         "input_file": {
-                            "filename": "autogen/starknet/event/SubmitTransaction/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/TransactionSubmitted/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 23,
+                                "end_col": 26,
                                 "end_line": 29,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -12595,11 +12595,11 @@
                                         "end_col": 94,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/event/SubmitTransaction/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                                            "filename": "autogen/starknet/event/TransactionSubmitted/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 23,
+                                                "end_col": 26,
                                                 "end_line": 29,
                                                 "input_file": {
                                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -12626,8 +12626,8 @@
                 "528": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.SubmitTransaction",
-                        "__main__.SubmitTransaction.emit"
+                        "__main__.TransactionSubmitted",
+                        "__main__.TransactionSubmitted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -12635,11 +12635,11 @@
                         "end_col": 95,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/SubmitTransaction/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                            "filename": "autogen/starknet/event/TransactionSubmitted/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 23,
+                                "end_col": 26,
                                 "end_line": 29,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -12656,8 +12656,8 @@
                 "530": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.SubmitTransaction",
-                        "__main__.SubmitTransaction.emit"
+                        "__main__.TransactionSubmitted",
+                        "__main__.TransactionSubmitted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -12665,11 +12665,11 @@
                         "end_col": 47,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/SubmitTransaction/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                            "filename": "autogen/starknet/event/TransactionSubmitted/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 23,
+                                "end_col": 26,
                                 "end_line": 29,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -12679,11 +12679,11 @@
                                         "end_col": 47,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/event/SubmitTransaction/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                                            "filename": "autogen/starknet/event/TransactionSubmitted/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 23,
+                                                "end_col": 26,
                                                 "end_line": 29,
                                                 "input_file": {
                                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -12693,11 +12693,11 @@
                                                         "end_col": 10,
                                                         "end_line": 2,
                                                         "input_file": {
-                                                            "filename": "autogen/starknet/event/SubmitTransaction/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                                                            "filename": "autogen/starknet/event/TransactionSubmitted/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                                                         },
                                                         "parent_location": [
                                                             {
-                                                                "end_col": 23,
+                                                                "end_col": 26,
                                                                 "end_line": 29,
                                                                 "input_file": {
                                                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -12734,8 +12734,8 @@
                 "531": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.SubmitTransaction",
-                        "__main__.SubmitTransaction.emit"
+                        "__main__.TransactionSubmitted",
+                        "__main__.TransactionSubmitted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -12743,11 +12743,11 @@
                         "end_col": 10,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/event/SubmitTransaction/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                            "filename": "autogen/starknet/event/TransactionSubmitted/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 23,
+                                "end_col": 26,
                                 "end_line": 29,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -12764,8 +12764,8 @@
                 "532": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ConfirmTransaction",
-                        "__main__.ConfirmTransaction.emit"
+                        "__main__.TransactionConfirmed",
+                        "__main__.TransactionConfirmed.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -12773,11 +12773,11 @@
                         "end_col": 13,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/ConfirmTransaction/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/TransactionConfirmed/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 26,
                                 "end_line": 36,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -12794,8 +12794,8 @@
                 "534": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ConfirmTransaction",
-                        "__main__.ConfirmTransaction.emit"
+                        "__main__.TransactionConfirmed",
+                        "__main__.TransactionConfirmed.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -12803,11 +12803,11 @@
                         "end_col": 41,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/event/ConfirmTransaction/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/TransactionConfirmed/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 26,
                                 "end_line": 36,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -12824,8 +12824,8 @@
                 "536": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ConfirmTransaction",
-                        "__main__.ConfirmTransaction.emit"
+                        "__main__.TransactionConfirmed",
+                        "__main__.TransactionConfirmed.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -12833,11 +12833,11 @@
                         "end_col": 30,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/event/ConfirmTransaction/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/TransactionConfirmed/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 26,
                                 "end_line": 36,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -12854,8 +12854,8 @@
                 "537": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ConfirmTransaction",
-                        "__main__.ConfirmTransaction.emit"
+                        "__main__.TransactionConfirmed",
+                        "__main__.TransactionConfirmed.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -12863,11 +12863,11 @@
                         "end_col": 31,
                         "end_line": 3,
                         "input_file": {
-                            "filename": "autogen/starknet/event/ConfirmTransaction/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/TransactionConfirmed/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 26,
                                 "end_line": 36,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -12884,8 +12884,8 @@
                 "539": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ConfirmTransaction",
-                        "__main__.ConfirmTransaction.emit"
+                        "__main__.TransactionConfirmed",
+                        "__main__.TransactionConfirmed.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -12893,11 +12893,11 @@
                         "end_col": 31,
                         "end_line": 3,
                         "input_file": {
-                            "filename": "autogen/starknet/event/ConfirmTransaction/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/TransactionConfirmed/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 26,
                                 "end_line": 36,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -12914,8 +12914,8 @@
                 "540": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ConfirmTransaction",
-                        "__main__.ConfirmTransaction.emit"
+                        "__main__.TransactionConfirmed",
+                        "__main__.TransactionConfirmed.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -12923,11 +12923,11 @@
                         "end_col": 41,
                         "end_line": 4,
                         "input_file": {
-                            "filename": "autogen/starknet/event/ConfirmTransaction/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/TransactionConfirmed/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 26,
                                 "end_line": 36,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -12944,8 +12944,8 @@
                 "542": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ConfirmTransaction",
-                        "__main__.ConfirmTransaction.emit"
+                        "__main__.TransactionConfirmed",
+                        "__main__.TransactionConfirmed.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -12953,11 +12953,11 @@
                         "end_col": 30,
                         "end_line": 4,
                         "input_file": {
-                            "filename": "autogen/starknet/event/ConfirmTransaction/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/TransactionConfirmed/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 26,
                                 "end_line": 36,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -12974,8 +12974,8 @@
                 "543": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ConfirmTransaction",
-                        "__main__.ConfirmTransaction.emit"
+                        "__main__.TransactionConfirmed",
+                        "__main__.TransactionConfirmed.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -12987,12 +12987,12 @@
                         },
                         "parent_location": [
                             {
-                                "end_col": 31,
+                                "end_col": 33,
                                 "end_line": 36,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
                                 },
-                                "start_col": 25,
+                                "start_col": 27,
                                 "start_line": 36
                             },
                             "While handling calldata argument 'signer'"
@@ -13004,8 +13004,8 @@
                 "544": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ConfirmTransaction",
-                        "__main__.ConfirmTransaction.emit"
+                        "__main__.TransactionConfirmed",
+                        "__main__.TransactionConfirmed.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -13017,12 +13017,12 @@
                         },
                         "parent_location": [
                             {
-                                "end_col": 45,
+                                "end_col": 47,
                                 "end_line": 36,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
                                 },
-                                "start_col": 40,
+                                "start_col": 42,
                                 "start_line": 36
                             },
                             "While handling calldata argument 'nonce'"
@@ -13034,8 +13034,8 @@
                 "545": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ConfirmTransaction",
-                        "__main__.ConfirmTransaction.emit"
+                        "__main__.TransactionConfirmed",
+                        "__main__.TransactionConfirmed.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -13047,7 +13047,7 @@
                         },
                         "parent_location": [
                             {
-                                "end_col": 45,
+                                "end_col": 47,
                                 "end_line": 36,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -13057,11 +13057,11 @@
                                         "end_col": 64,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/event/ConfirmTransaction/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                                            "filename": "autogen/starknet/event/TransactionConfirmed/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 24,
+                                                "end_col": 26,
                                                 "end_line": 36,
                                                 "input_file": {
                                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -13076,7 +13076,7 @@
                                     },
                                     "While expanding the reference '__calldata_ptr' in:"
                                 ],
-                                "start_col": 40,
+                                "start_col": 42,
                                 "start_line": 36
                             },
                             "While handling calldata argument 'nonce'"
@@ -13088,8 +13088,8 @@
                 "547": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ConfirmTransaction",
-                        "__main__.ConfirmTransaction.emit"
+                        "__main__.TransactionConfirmed",
+                        "__main__.TransactionConfirmed.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -13097,11 +13097,11 @@
                         "end_col": 30,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/ConfirmTransaction/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                            "filename": "autogen/starknet/event/TransactionConfirmed/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 26,
                                 "end_line": 36,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -13109,7 +13109,7 @@
                                 "parent_location": [
                                     {
                                         "end_col": 36,
-                                        "end_line": 383,
+                                        "end_line": 385,
                                         "input_file": {
                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                         },
@@ -13118,11 +13118,11 @@
                                                 "end_col": 95,
                                                 "end_line": 1,
                                                 "input_file": {
-                                                    "filename": "autogen/starknet/event/ConfirmTransaction/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                                                    "filename": "autogen/starknet/event/TransactionConfirmed/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                                                 },
                                                 "parent_location": [
                                                     {
-                                                        "end_col": 24,
+                                                        "end_col": 26,
                                                         "end_line": 36,
                                                         "input_file": {
                                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -13138,7 +13138,7 @@
                                             "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                         ],
                                         "start_col": 17,
-                                        "start_line": 383
+                                        "start_line": 385
                                     },
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
@@ -13154,8 +13154,8 @@
                 "548": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ConfirmTransaction",
-                        "__main__.ConfirmTransaction.emit"
+                        "__main__.TransactionConfirmed",
+                        "__main__.TransactionConfirmed.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -13163,11 +13163,11 @@
                         "end_col": 22,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/ConfirmTransaction/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                            "filename": "autogen/starknet/event/TransactionConfirmed/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 26,
                                 "end_line": 36,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -13184,8 +13184,8 @@
                 "550": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ConfirmTransaction",
-                        "__main__.ConfirmTransaction.emit"
+                        "__main__.TransactionConfirmed",
+                        "__main__.TransactionConfirmed.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -13193,11 +13193,11 @@
                         "end_col": 22,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/event/ConfirmTransaction/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/TransactionConfirmed/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 26,
                                 "end_line": 36,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -13207,11 +13207,11 @@
                                         "end_col": 39,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/event/ConfirmTransaction/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                                            "filename": "autogen/starknet/event/TransactionConfirmed/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 24,
+                                                "end_col": 26,
                                                 "end_line": 36,
                                                 "input_file": {
                                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -13238,8 +13238,8 @@
                 "551": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ConfirmTransaction",
-                        "__main__.ConfirmTransaction.emit"
+                        "__main__.TransactionConfirmed",
+                        "__main__.TransactionConfirmed.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -13247,11 +13247,11 @@
                         "end_col": 77,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/ConfirmTransaction/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                            "filename": "autogen/starknet/event/TransactionConfirmed/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 26,
                                 "end_line": 36,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -13268,8 +13268,8 @@
                 "552": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ConfirmTransaction",
-                        "__main__.ConfirmTransaction.emit"
+                        "__main__.TransactionConfirmed",
+                        "__main__.TransactionConfirmed.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -13277,11 +13277,11 @@
                         "end_col": 22,
                         "end_line": 4,
                         "input_file": {
-                            "filename": "autogen/starknet/event/ConfirmTransaction/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/TransactionConfirmed/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 26,
                                 "end_line": 36,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -13291,11 +13291,11 @@
                                         "end_col": 94,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/event/ConfirmTransaction/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                                            "filename": "autogen/starknet/event/TransactionConfirmed/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 24,
+                                                "end_col": 26,
                                                 "end_line": 36,
                                                 "input_file": {
                                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -13322,8 +13322,8 @@
                 "553": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ConfirmTransaction",
-                        "__main__.ConfirmTransaction.emit"
+                        "__main__.TransactionConfirmed",
+                        "__main__.TransactionConfirmed.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -13331,11 +13331,11 @@
                         "end_col": 95,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/ConfirmTransaction/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                            "filename": "autogen/starknet/event/TransactionConfirmed/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 26,
                                 "end_line": 36,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -13352,8 +13352,8 @@
                 "555": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ConfirmTransaction",
-                        "__main__.ConfirmTransaction.emit"
+                        "__main__.TransactionConfirmed",
+                        "__main__.TransactionConfirmed.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -13361,11 +13361,11 @@
                         "end_col": 47,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/ConfirmTransaction/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                            "filename": "autogen/starknet/event/TransactionConfirmed/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 26,
                                 "end_line": 36,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -13375,11 +13375,11 @@
                                         "end_col": 47,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/event/ConfirmTransaction/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                                            "filename": "autogen/starknet/event/TransactionConfirmed/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 24,
+                                                "end_col": 26,
                                                 "end_line": 36,
                                                 "input_file": {
                                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -13389,11 +13389,11 @@
                                                         "end_col": 10,
                                                         "end_line": 2,
                                                         "input_file": {
-                                                            "filename": "autogen/starknet/event/ConfirmTransaction/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                                                            "filename": "autogen/starknet/event/TransactionConfirmed/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                                                         },
                                                         "parent_location": [
                                                             {
-                                                                "end_col": 24,
+                                                                "end_col": 26,
                                                                 "end_line": 36,
                                                                 "input_file": {
                                                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -13430,8 +13430,8 @@
                 "556": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ConfirmTransaction",
-                        "__main__.ConfirmTransaction.emit"
+                        "__main__.TransactionConfirmed",
+                        "__main__.TransactionConfirmed.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -13439,11 +13439,11 @@
                         "end_col": 10,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/event/ConfirmTransaction/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                            "filename": "autogen/starknet/event/TransactionConfirmed/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 26,
                                 "end_line": 36,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -13460,8 +13460,8 @@
                 "557": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.RevokeConfirmation",
-                        "__main__.RevokeConfirmation.emit"
+                        "__main__.ConfirmationRevoked",
+                        "__main__.ConfirmationRevoked.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -13469,11 +13469,11 @@
                         "end_col": 13,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/RevokeConfirmation/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/ConfirmationRevoked/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 25,
                                 "end_line": 43,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -13490,8 +13490,8 @@
                 "559": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.RevokeConfirmation",
-                        "__main__.RevokeConfirmation.emit"
+                        "__main__.ConfirmationRevoked",
+                        "__main__.ConfirmationRevoked.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -13499,11 +13499,11 @@
                         "end_col": 41,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/event/RevokeConfirmation/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/ConfirmationRevoked/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 25,
                                 "end_line": 43,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -13520,8 +13520,8 @@
                 "561": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.RevokeConfirmation",
-                        "__main__.RevokeConfirmation.emit"
+                        "__main__.ConfirmationRevoked",
+                        "__main__.ConfirmationRevoked.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -13529,11 +13529,11 @@
                         "end_col": 30,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/event/RevokeConfirmation/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/ConfirmationRevoked/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 25,
                                 "end_line": 43,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -13550,8 +13550,8 @@
                 "562": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.RevokeConfirmation",
-                        "__main__.RevokeConfirmation.emit"
+                        "__main__.ConfirmationRevoked",
+                        "__main__.ConfirmationRevoked.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -13559,11 +13559,11 @@
                         "end_col": 31,
                         "end_line": 3,
                         "input_file": {
-                            "filename": "autogen/starknet/event/RevokeConfirmation/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/ConfirmationRevoked/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 25,
                                 "end_line": 43,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -13580,8 +13580,8 @@
                 "564": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.RevokeConfirmation",
-                        "__main__.RevokeConfirmation.emit"
+                        "__main__.ConfirmationRevoked",
+                        "__main__.ConfirmationRevoked.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -13589,11 +13589,11 @@
                         "end_col": 31,
                         "end_line": 3,
                         "input_file": {
-                            "filename": "autogen/starknet/event/RevokeConfirmation/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/ConfirmationRevoked/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 25,
                                 "end_line": 43,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -13610,8 +13610,8 @@
                 "565": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.RevokeConfirmation",
-                        "__main__.RevokeConfirmation.emit"
+                        "__main__.ConfirmationRevoked",
+                        "__main__.ConfirmationRevoked.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -13619,11 +13619,11 @@
                         "end_col": 41,
                         "end_line": 4,
                         "input_file": {
-                            "filename": "autogen/starknet/event/RevokeConfirmation/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/ConfirmationRevoked/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 25,
                                 "end_line": 43,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -13640,8 +13640,8 @@
                 "567": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.RevokeConfirmation",
-                        "__main__.RevokeConfirmation.emit"
+                        "__main__.ConfirmationRevoked",
+                        "__main__.ConfirmationRevoked.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -13649,11 +13649,11 @@
                         "end_col": 30,
                         "end_line": 4,
                         "input_file": {
-                            "filename": "autogen/starknet/event/RevokeConfirmation/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/ConfirmationRevoked/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 25,
                                 "end_line": 43,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -13670,8 +13670,8 @@
                 "568": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.RevokeConfirmation",
-                        "__main__.RevokeConfirmation.emit"
+                        "__main__.ConfirmationRevoked",
+                        "__main__.ConfirmationRevoked.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -13683,12 +13683,12 @@
                         },
                         "parent_location": [
                             {
-                                "end_col": 31,
+                                "end_col": 32,
                                 "end_line": 43,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
                                 },
-                                "start_col": 25,
+                                "start_col": 26,
                                 "start_line": 43
                             },
                             "While handling calldata argument 'signer'"
@@ -13700,8 +13700,8 @@
                 "569": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.RevokeConfirmation",
-                        "__main__.RevokeConfirmation.emit"
+                        "__main__.ConfirmationRevoked",
+                        "__main__.ConfirmationRevoked.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -13713,12 +13713,12 @@
                         },
                         "parent_location": [
                             {
-                                "end_col": 45,
+                                "end_col": 46,
                                 "end_line": 43,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
                                 },
-                                "start_col": 40,
+                                "start_col": 41,
                                 "start_line": 43
                             },
                             "While handling calldata argument 'nonce'"
@@ -13730,8 +13730,8 @@
                 "570": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.RevokeConfirmation",
-                        "__main__.RevokeConfirmation.emit"
+                        "__main__.ConfirmationRevoked",
+                        "__main__.ConfirmationRevoked.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -13743,7 +13743,7 @@
                         },
                         "parent_location": [
                             {
-                                "end_col": 45,
+                                "end_col": 46,
                                 "end_line": 43,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -13753,11 +13753,11 @@
                                         "end_col": 64,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/event/RevokeConfirmation/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                                            "filename": "autogen/starknet/event/ConfirmationRevoked/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 24,
+                                                "end_col": 25,
                                                 "end_line": 43,
                                                 "input_file": {
                                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -13772,7 +13772,7 @@
                                     },
                                     "While expanding the reference '__calldata_ptr' in:"
                                 ],
-                                "start_col": 40,
+                                "start_col": 41,
                                 "start_line": 43
                             },
                             "While handling calldata argument 'nonce'"
@@ -13784,8 +13784,8 @@
                 "572": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.RevokeConfirmation",
-                        "__main__.RevokeConfirmation.emit"
+                        "__main__.ConfirmationRevoked",
+                        "__main__.ConfirmationRevoked.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -13793,11 +13793,11 @@
                         "end_col": 30,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/RevokeConfirmation/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                            "filename": "autogen/starknet/event/ConfirmationRevoked/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 25,
                                 "end_line": 43,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -13805,7 +13805,7 @@
                                 "parent_location": [
                                     {
                                         "end_col": 36,
-                                        "end_line": 383,
+                                        "end_line": 385,
                                         "input_file": {
                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                         },
@@ -13814,11 +13814,11 @@
                                                 "end_col": 95,
                                                 "end_line": 1,
                                                 "input_file": {
-                                                    "filename": "autogen/starknet/event/RevokeConfirmation/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                                                    "filename": "autogen/starknet/event/ConfirmationRevoked/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                                                 },
                                                 "parent_location": [
                                                     {
-                                                        "end_col": 24,
+                                                        "end_col": 25,
                                                         "end_line": 43,
                                                         "input_file": {
                                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -13834,7 +13834,7 @@
                                             "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                         ],
                                         "start_col": 17,
-                                        "start_line": 383
+                                        "start_line": 385
                                     },
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
@@ -13850,8 +13850,8 @@
                 "573": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.RevokeConfirmation",
-                        "__main__.RevokeConfirmation.emit"
+                        "__main__.ConfirmationRevoked",
+                        "__main__.ConfirmationRevoked.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -13859,11 +13859,11 @@
                         "end_col": 22,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/RevokeConfirmation/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                            "filename": "autogen/starknet/event/ConfirmationRevoked/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 25,
                                 "end_line": 43,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -13880,8 +13880,8 @@
                 "575": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.RevokeConfirmation",
-                        "__main__.RevokeConfirmation.emit"
+                        "__main__.ConfirmationRevoked",
+                        "__main__.ConfirmationRevoked.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -13889,11 +13889,11 @@
                         "end_col": 22,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/event/RevokeConfirmation/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/ConfirmationRevoked/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 25,
                                 "end_line": 43,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -13903,11 +13903,11 @@
                                         "end_col": 39,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/event/RevokeConfirmation/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                                            "filename": "autogen/starknet/event/ConfirmationRevoked/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 24,
+                                                "end_col": 25,
                                                 "end_line": 43,
                                                 "input_file": {
                                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -13934,8 +13934,8 @@
                 "576": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.RevokeConfirmation",
-                        "__main__.RevokeConfirmation.emit"
+                        "__main__.ConfirmationRevoked",
+                        "__main__.ConfirmationRevoked.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -13943,11 +13943,11 @@
                         "end_col": 77,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/RevokeConfirmation/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                            "filename": "autogen/starknet/event/ConfirmationRevoked/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 25,
                                 "end_line": 43,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -13964,8 +13964,8 @@
                 "577": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.RevokeConfirmation",
-                        "__main__.RevokeConfirmation.emit"
+                        "__main__.ConfirmationRevoked",
+                        "__main__.ConfirmationRevoked.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -13973,11 +13973,11 @@
                         "end_col": 22,
                         "end_line": 4,
                         "input_file": {
-                            "filename": "autogen/starknet/event/RevokeConfirmation/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/ConfirmationRevoked/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 25,
                                 "end_line": 43,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -13987,11 +13987,11 @@
                                         "end_col": 94,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/event/RevokeConfirmation/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                                            "filename": "autogen/starknet/event/ConfirmationRevoked/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 24,
+                                                "end_col": 25,
                                                 "end_line": 43,
                                                 "input_file": {
                                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -14018,8 +14018,8 @@
                 "578": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.RevokeConfirmation",
-                        "__main__.RevokeConfirmation.emit"
+                        "__main__.ConfirmationRevoked",
+                        "__main__.ConfirmationRevoked.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -14027,11 +14027,11 @@
                         "end_col": 95,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/RevokeConfirmation/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                            "filename": "autogen/starknet/event/ConfirmationRevoked/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 25,
                                 "end_line": 43,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -14048,8 +14048,8 @@
                 "580": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.RevokeConfirmation",
-                        "__main__.RevokeConfirmation.emit"
+                        "__main__.ConfirmationRevoked",
+                        "__main__.ConfirmationRevoked.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -14057,11 +14057,11 @@
                         "end_col": 47,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/RevokeConfirmation/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                            "filename": "autogen/starknet/event/ConfirmationRevoked/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 25,
                                 "end_line": 43,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -14071,11 +14071,11 @@
                                         "end_col": 47,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/event/RevokeConfirmation/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                                            "filename": "autogen/starknet/event/ConfirmationRevoked/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 24,
+                                                "end_col": 25,
                                                 "end_line": 43,
                                                 "input_file": {
                                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -14085,11 +14085,11 @@
                                                         "end_col": 10,
                                                         "end_line": 2,
                                                         "input_file": {
-                                                            "filename": "autogen/starknet/event/RevokeConfirmation/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                                                            "filename": "autogen/starknet/event/ConfirmationRevoked/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                                                         },
                                                         "parent_location": [
                                                             {
-                                                                "end_col": 24,
+                                                                "end_col": 25,
                                                                 "end_line": 43,
                                                                 "input_file": {
                                                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -14126,8 +14126,8 @@
                 "581": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.RevokeConfirmation",
-                        "__main__.RevokeConfirmation.emit"
+                        "__main__.ConfirmationRevoked",
+                        "__main__.ConfirmationRevoked.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -14135,11 +14135,11 @@
                         "end_col": 10,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/event/RevokeConfirmation/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                            "filename": "autogen/starknet/event/ConfirmationRevoked/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 25,
                                 "end_line": 43,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -14156,8 +14156,8 @@
                 "582": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ExecuteTransaction",
-                        "__main__.ExecuteTransaction.emit"
+                        "__main__.TransactionExecuted",
+                        "__main__.TransactionExecuted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -14165,11 +14165,11 @@
                         "end_col": 13,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/ExecuteTransaction/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/TransactionExecuted/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 25,
                                 "end_line": 50,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -14186,8 +14186,8 @@
                 "584": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ExecuteTransaction",
-                        "__main__.ExecuteTransaction.emit"
+                        "__main__.TransactionExecuted",
+                        "__main__.TransactionExecuted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -14195,11 +14195,11 @@
                         "end_col": 41,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/event/ExecuteTransaction/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/TransactionExecuted/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 25,
                                 "end_line": 50,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -14216,8 +14216,8 @@
                 "586": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ExecuteTransaction",
-                        "__main__.ExecuteTransaction.emit"
+                        "__main__.TransactionExecuted",
+                        "__main__.TransactionExecuted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -14225,11 +14225,11 @@
                         "end_col": 30,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/event/ExecuteTransaction/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/TransactionExecuted/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 25,
                                 "end_line": 50,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -14246,8 +14246,8 @@
                 "587": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ExecuteTransaction",
-                        "__main__.ExecuteTransaction.emit"
+                        "__main__.TransactionExecuted",
+                        "__main__.TransactionExecuted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -14255,11 +14255,11 @@
                         "end_col": 31,
                         "end_line": 3,
                         "input_file": {
-                            "filename": "autogen/starknet/event/ExecuteTransaction/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/TransactionExecuted/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 25,
                                 "end_line": 50,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -14276,8 +14276,8 @@
                 "589": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ExecuteTransaction",
-                        "__main__.ExecuteTransaction.emit"
+                        "__main__.TransactionExecuted",
+                        "__main__.TransactionExecuted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -14285,11 +14285,11 @@
                         "end_col": 31,
                         "end_line": 3,
                         "input_file": {
-                            "filename": "autogen/starknet/event/ExecuteTransaction/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/TransactionExecuted/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 25,
                                 "end_line": 50,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -14306,8 +14306,8 @@
                 "590": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ExecuteTransaction",
-                        "__main__.ExecuteTransaction.emit"
+                        "__main__.TransactionExecuted",
+                        "__main__.TransactionExecuted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -14315,11 +14315,11 @@
                         "end_col": 41,
                         "end_line": 4,
                         "input_file": {
-                            "filename": "autogen/starknet/event/ExecuteTransaction/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/TransactionExecuted/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 25,
                                 "end_line": 50,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -14336,8 +14336,8 @@
                 "592": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ExecuteTransaction",
-                        "__main__.ExecuteTransaction.emit"
+                        "__main__.TransactionExecuted",
+                        "__main__.TransactionExecuted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -14345,11 +14345,11 @@
                         "end_col": 30,
                         "end_line": 4,
                         "input_file": {
-                            "filename": "autogen/starknet/event/ExecuteTransaction/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/TransactionExecuted/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 25,
                                 "end_line": 50,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -14366,8 +14366,8 @@
                 "593": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ExecuteTransaction",
-                        "__main__.ExecuteTransaction.emit"
+                        "__main__.TransactionExecuted",
+                        "__main__.TransactionExecuted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -14379,12 +14379,12 @@
                         },
                         "parent_location": [
                             {
-                                "end_col": 33,
+                                "end_col": 34,
                                 "end_line": 50,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
                                 },
-                                "start_col": 25,
+                                "start_col": 26,
                                 "start_line": 50
                             },
                             "While handling calldata argument 'executer'"
@@ -14396,8 +14396,8 @@
                 "594": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ExecuteTransaction",
-                        "__main__.ExecuteTransaction.emit"
+                        "__main__.TransactionExecuted",
+                        "__main__.TransactionExecuted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -14409,12 +14409,12 @@
                         },
                         "parent_location": [
                             {
-                                "end_col": 47,
+                                "end_col": 48,
                                 "end_line": 50,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
                                 },
-                                "start_col": 42,
+                                "start_col": 43,
                                 "start_line": 50
                             },
                             "While handling calldata argument 'nonce'"
@@ -14426,8 +14426,8 @@
                 "595": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ExecuteTransaction",
-                        "__main__.ExecuteTransaction.emit"
+                        "__main__.TransactionExecuted",
+                        "__main__.TransactionExecuted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -14439,7 +14439,7 @@
                         },
                         "parent_location": [
                             {
-                                "end_col": 47,
+                                "end_col": 48,
                                 "end_line": 50,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -14449,11 +14449,11 @@
                                         "end_col": 64,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/event/ExecuteTransaction/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                                            "filename": "autogen/starknet/event/TransactionExecuted/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 24,
+                                                "end_col": 25,
                                                 "end_line": 50,
                                                 "input_file": {
                                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -14468,7 +14468,7 @@
                                     },
                                     "While expanding the reference '__calldata_ptr' in:"
                                 ],
-                                "start_col": 42,
+                                "start_col": 43,
                                 "start_line": 50
                             },
                             "While handling calldata argument 'nonce'"
@@ -14480,8 +14480,8 @@
                 "597": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ExecuteTransaction",
-                        "__main__.ExecuteTransaction.emit"
+                        "__main__.TransactionExecuted",
+                        "__main__.TransactionExecuted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -14489,11 +14489,11 @@
                         "end_col": 30,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/ExecuteTransaction/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                            "filename": "autogen/starknet/event/TransactionExecuted/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 25,
                                 "end_line": 50,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -14501,7 +14501,7 @@
                                 "parent_location": [
                                     {
                                         "end_col": 36,
-                                        "end_line": 383,
+                                        "end_line": 385,
                                         "input_file": {
                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                         },
@@ -14510,11 +14510,11 @@
                                                 "end_col": 95,
                                                 "end_line": 1,
                                                 "input_file": {
-                                                    "filename": "autogen/starknet/event/ExecuteTransaction/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                                                    "filename": "autogen/starknet/event/TransactionExecuted/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                                                 },
                                                 "parent_location": [
                                                     {
-                                                        "end_col": 24,
+                                                        "end_col": 25,
                                                         "end_line": 50,
                                                         "input_file": {
                                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -14530,7 +14530,7 @@
                                             "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                         ],
                                         "start_col": 17,
-                                        "start_line": 383
+                                        "start_line": 385
                                     },
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
@@ -14546,8 +14546,8 @@
                 "598": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ExecuteTransaction",
-                        "__main__.ExecuteTransaction.emit"
+                        "__main__.TransactionExecuted",
+                        "__main__.TransactionExecuted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -14555,11 +14555,11 @@
                         "end_col": 22,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/ExecuteTransaction/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                            "filename": "autogen/starknet/event/TransactionExecuted/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 25,
                                 "end_line": 50,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -14576,8 +14576,8 @@
                 "600": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ExecuteTransaction",
-                        "__main__.ExecuteTransaction.emit"
+                        "__main__.TransactionExecuted",
+                        "__main__.TransactionExecuted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -14585,11 +14585,11 @@
                         "end_col": 22,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/event/ExecuteTransaction/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/TransactionExecuted/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 25,
                                 "end_line": 50,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -14599,11 +14599,11 @@
                                         "end_col": 39,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/event/ExecuteTransaction/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                                            "filename": "autogen/starknet/event/TransactionExecuted/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 24,
+                                                "end_col": 25,
                                                 "end_line": 50,
                                                 "input_file": {
                                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -14630,8 +14630,8 @@
                 "601": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ExecuteTransaction",
-                        "__main__.ExecuteTransaction.emit"
+                        "__main__.TransactionExecuted",
+                        "__main__.TransactionExecuted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -14639,11 +14639,11 @@
                         "end_col": 77,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/ExecuteTransaction/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                            "filename": "autogen/starknet/event/TransactionExecuted/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 25,
                                 "end_line": 50,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -14660,8 +14660,8 @@
                 "602": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ExecuteTransaction",
-                        "__main__.ExecuteTransaction.emit"
+                        "__main__.TransactionExecuted",
+                        "__main__.TransactionExecuted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -14669,11 +14669,11 @@
                         "end_col": 22,
                         "end_line": 4,
                         "input_file": {
-                            "filename": "autogen/starknet/event/ExecuteTransaction/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
+                            "filename": "autogen/starknet/event/TransactionExecuted/65c5085194e774f24b349fa5ca17d70e9ee7479a2b72fa6bed01a6505af19ff9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 25,
                                 "end_line": 50,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -14683,11 +14683,11 @@
                                         "end_col": 94,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/event/ExecuteTransaction/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                                            "filename": "autogen/starknet/event/TransactionExecuted/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 24,
+                                                "end_col": 25,
                                                 "end_line": 50,
                                                 "input_file": {
                                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -14714,8 +14714,8 @@
                 "603": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ExecuteTransaction",
-                        "__main__.ExecuteTransaction.emit"
+                        "__main__.TransactionExecuted",
+                        "__main__.TransactionExecuted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -14723,11 +14723,11 @@
                         "end_col": 95,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/ExecuteTransaction/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                            "filename": "autogen/starknet/event/TransactionExecuted/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 25,
                                 "end_line": 50,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -14744,8 +14744,8 @@
                 "605": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ExecuteTransaction",
-                        "__main__.ExecuteTransaction.emit"
+                        "__main__.TransactionExecuted",
+                        "__main__.TransactionExecuted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -14753,11 +14753,11 @@
                         "end_col": 47,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/ExecuteTransaction/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                            "filename": "autogen/starknet/event/TransactionExecuted/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 25,
                                 "end_line": 50,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -14767,11 +14767,11 @@
                                         "end_col": 47,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/event/ExecuteTransaction/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                                            "filename": "autogen/starknet/event/TransactionExecuted/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 24,
+                                                "end_col": 25,
                                                 "end_line": 50,
                                                 "input_file": {
                                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -14781,11 +14781,11 @@
                                                         "end_col": 10,
                                                         "end_line": 2,
                                                         "input_file": {
-                                                            "filename": "autogen/starknet/event/ExecuteTransaction/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                                                            "filename": "autogen/starknet/event/TransactionExecuted/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                                                         },
                                                         "parent_location": [
                                                             {
-                                                                "end_col": 24,
+                                                                "end_col": 25,
                                                                 "end_line": 50,
                                                                 "input_file": {
                                                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -14822,8 +14822,8 @@
                 "606": {
                     "accessible_scopes": [
                         "__main__",
-                        "__main__.ExecuteTransaction",
-                        "__main__.ExecuteTransaction.emit"
+                        "__main__.TransactionExecuted",
+                        "__main__.TransactionExecuted.emit"
                     ],
                     "flow_tracking_data": null,
                     "hints": [],
@@ -14831,11 +14831,11 @@
                         "end_col": 10,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/event/ExecuteTransaction/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
+                            "filename": "autogen/starknet/event/TransactionExecuted/858f2c0e8fdda3108b2e383053abb5bae67b6b5a2bf306a848bd20c7d5507d8c.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 25,
                                 "end_line": 50,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -15449,7 +15449,7 @@
                                 "parent_location": [
                                     {
                                         "end_col": 36,
-                                        "end_line": 383,
+                                        "end_line": 385,
                                         "input_file": {
                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                         },
@@ -15478,7 +15478,7 @@
                                             "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                         ],
                                         "start_col": 17,
-                                        "start_line": 383
+                                        "start_line": 385
                                     },
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
@@ -16115,7 +16115,7 @@
                                 "parent_location": [
                                     {
                                         "end_col": 36,
-                                        "end_line": 383,
+                                        "end_line": 385,
                                         "input_file": {
                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                         },
@@ -16144,7 +16144,7 @@
                                             "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                         ],
                                         "start_col": 17,
-                                        "start_line": 383
+                                        "start_line": 385
                                     },
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
@@ -16714,7 +16714,7 @@
                         "parent_location": [
                             {
                                 "end_col": 38,
-                                "end_line": 346,
+                                "end_line": 348,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
@@ -16731,7 +16731,7 @@
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 19,
-                                "start_line": 346
+                                "start_line": 348
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
@@ -16797,7 +16797,7 @@
                     "hints": [],
                     "inst": {
                         "end_col": 38,
-                        "end_line": 346,
+                        "end_line": 348,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
@@ -16826,7 +16826,7 @@
                             "While trying to update the implicit return value 'syscall_ptr' in:"
                         ],
                         "start_col": 19,
-                        "start_line": 346
+                        "start_line": 348
                     }
                 },
                 "679": {
@@ -17080,7 +17080,7 @@
                         "parent_location": [
                             {
                                 "end_col": 39,
-                                "end_line": 364,
+                                "end_line": 366,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
@@ -17097,7 +17097,7 @@
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 20,
-                                "start_line": 364
+                                "start_line": 366
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
@@ -17548,7 +17548,7 @@
                         "parent_location": [
                             {
                                 "end_col": 38,
-                                "end_line": 346,
+                                "end_line": 348,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
@@ -17565,7 +17565,7 @@
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 19,
-                                "start_line": 346
+                                "start_line": 348
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
@@ -17631,7 +17631,7 @@
                     "hints": [],
                     "inst": {
                         "end_col": 38,
-                        "end_line": 346,
+                        "end_line": 348,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
@@ -17660,7 +17660,7 @@
                             "While trying to update the implicit return value 'syscall_ptr' in:"
                         ],
                         "start_col": 19,
-                        "start_line": 346
+                        "start_line": 348
                     }
                 },
                 "709": {
@@ -17914,7 +17914,7 @@
                         "parent_location": [
                             {
                                 "end_col": 39,
-                                "end_line": 364,
+                                "end_line": 366,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
@@ -17931,7 +17931,7 @@
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 20,
-                                "start_line": 364
+                                "start_line": 366
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
@@ -18610,7 +18610,7 @@
                         "parent_location": [
                             {
                                 "end_col": 38,
-                                "end_line": 346,
+                                "end_line": 348,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
@@ -18627,7 +18627,7 @@
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 19,
-                                "start_line": 346
+                                "start_line": 348
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
@@ -18693,7 +18693,7 @@
                     "hints": [],
                     "inst": {
                         "end_col": 38,
-                        "end_line": 346,
+                        "end_line": 348,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
@@ -18722,7 +18722,7 @@
                             "While trying to update the implicit return value 'syscall_ptr' in:"
                         ],
                         "start_col": 19,
-                        "start_line": 346
+                        "start_line": 348
                     }
                 },
                 "749": {
@@ -19006,7 +19006,7 @@
                         "parent_location": [
                             {
                                 "end_col": 39,
-                                "end_line": 364,
+                                "end_line": 366,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
@@ -19023,7 +19023,7 @@
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 20,
-                                "start_line": 364
+                                "start_line": 366
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
@@ -19474,7 +19474,7 @@
                         "parent_location": [
                             {
                                 "end_col": 38,
-                                "end_line": 346,
+                                "end_line": 348,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
@@ -19491,7 +19491,7 @@
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 19,
-                                "start_line": 346
+                                "start_line": 348
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
@@ -19557,7 +19557,7 @@
                     "hints": [],
                     "inst": {
                         "end_col": 38,
-                        "end_line": 346,
+                        "end_line": 348,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
@@ -19586,7 +19586,7 @@
                             "While trying to update the implicit return value 'syscall_ptr' in:"
                         ],
                         "start_col": 19,
-                        "start_line": 346
+                        "start_line": 348
                     }
                 },
                 "780": {
@@ -19840,7 +19840,7 @@
                         "parent_location": [
                             {
                                 "end_col": 39,
-                                "end_line": 364,
+                                "end_line": 366,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
@@ -19857,7 +19857,7 @@
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 20,
-                                "start_line": 364
+                                "start_line": 366
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
@@ -20536,7 +20536,7 @@
                         "parent_location": [
                             {
                                 "end_col": 38,
-                                "end_line": 346,
+                                "end_line": 348,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
@@ -20553,7 +20553,7 @@
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 19,
-                                "start_line": 346
+                                "start_line": 348
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
@@ -20619,7 +20619,7 @@
                     "hints": [],
                     "inst": {
                         "end_col": 38,
-                        "end_line": 346,
+                        "end_line": 348,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
@@ -20648,7 +20648,7 @@
                             "While trying to update the implicit return value 'syscall_ptr' in:"
                         ],
                         "start_col": 19,
-                        "start_line": 346
+                        "start_line": 348
                     }
                 },
                 "820": {
@@ -20932,7 +20932,7 @@
                         "parent_location": [
                             {
                                 "end_col": 39,
-                                "end_line": 364,
+                                "end_line": 366,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
@@ -20949,7 +20949,7 @@
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 20,
-                                "start_line": 364
+                                "start_line": 366
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
@@ -21400,7 +21400,7 @@
                         "parent_location": [
                             {
                                 "end_col": 38,
-                                "end_line": 346,
+                                "end_line": 348,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
@@ -21417,7 +21417,7 @@
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 19,
-                                "start_line": 346
+                                "start_line": 348
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
@@ -21483,7 +21483,7 @@
                     "hints": [],
                     "inst": {
                         "end_col": 38,
-                        "end_line": 346,
+                        "end_line": 348,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
@@ -21512,7 +21512,7 @@
                             "While trying to update the implicit return value 'syscall_ptr' in:"
                         ],
                         "start_col": 19,
-                        "start_line": 346
+                        "start_line": 348
                     }
                 },
                 "851": {
@@ -21766,7 +21766,7 @@
                         "parent_location": [
                             {
                                 "end_col": 39,
-                                "end_line": 364,
+                                "end_line": 366,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
@@ -21783,7 +21783,7 @@
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 20,
-                                "start_line": 364
+                                "start_line": 366
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
@@ -22528,7 +22528,7 @@
                         "parent_location": [
                             {
                                 "end_col": 38,
-                                "end_line": 346,
+                                "end_line": 348,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
@@ -22545,7 +22545,7 @@
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 19,
-                                "start_line": 346
+                                "start_line": 348
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
@@ -22611,7 +22611,7 @@
                     "hints": [],
                     "inst": {
                         "end_col": 38,
-                        "end_line": 346,
+                        "end_line": 348,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
@@ -22640,7 +22640,7 @@
                             "While trying to update the implicit return value 'syscall_ptr' in:"
                         ],
                         "start_col": 19,
-                        "start_line": 346
+                        "start_line": 348
                     }
                 },
                 "895": {
@@ -22954,7 +22954,7 @@
                         "parent_location": [
                             {
                                 "end_col": 39,
-                                "end_line": 364,
+                                "end_line": 366,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
@@ -22971,7 +22971,7 @@
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 20,
-                                "start_line": 364
+                                "start_line": 366
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
@@ -23716,7 +23716,7 @@
                         "parent_location": [
                             {
                                 "end_col": 38,
-                                "end_line": 346,
+                                "end_line": 348,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
@@ -23733,7 +23733,7 @@
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 19,
-                                "start_line": 346
+                                "start_line": 348
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
@@ -23799,7 +23799,7 @@
                     "hints": [],
                     "inst": {
                         "end_col": 38,
-                        "end_line": 346,
+                        "end_line": 348,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
@@ -23828,7 +23828,7 @@
                             "While trying to update the implicit return value 'syscall_ptr' in:"
                         ],
                         "start_col": 19,
-                        "start_line": 346
+                        "start_line": 348
                     }
                 },
                 "941": {
@@ -24142,7 +24142,7 @@
                         "parent_location": [
                             {
                                 "end_col": 39,
-                                "end_line": 364,
+                                "end_line": 366,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
@@ -24159,7 +24159,7 @@
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 20,
-                                "start_line": 364
+                                "start_line": 366
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
@@ -24904,7 +24904,7 @@
                         "parent_location": [
                             {
                                 "end_col": 38,
-                                "end_line": 346,
+                                "end_line": 348,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
@@ -24921,7 +24921,7 @@
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 19,
-                                "start_line": 346
+                                "start_line": 348
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
@@ -24987,7 +24987,7 @@
                     "hints": [],
                     "inst": {
                         "end_col": 38,
-                        "end_line": 346,
+                        "end_line": 348,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
@@ -25016,7 +25016,7 @@
                             "While trying to update the implicit return value 'syscall_ptr' in:"
                         ],
                         "start_col": 19,
-                        "start_line": 346
+                        "start_line": 348
                     }
                 },
                 "987": {
@@ -25330,7 +25330,7 @@
                         "parent_location": [
                             {
                                 "end_col": 39,
-                                "end_line": 364,
+                                "end_line": 366,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
@@ -25347,7 +25347,7 @@
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 20,
-                                "start_line": 364
+                                "start_line": 366
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
@@ -25563,7 +25563,7 @@
                         "parent_location": [
                             {
                                 "end_col": 44,
-                                "end_line": 194,
+                                "end_line": 196,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
@@ -25580,7 +25580,7 @@
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 25,
-                                "start_line": 194
+                                "start_line": 196
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
@@ -25614,7 +25614,7 @@
                     "hints": [],
                     "inst": {
                         "end_col": 44,
-                        "end_line": 194,
+                        "end_line": 196,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
@@ -25655,7 +25655,7 @@
                             "While trying to update the implicit return value 'syscall_ptr' in:"
                         ],
                         "start_col": 25,
-                        "start_line": 194
+                        "start_line": 196
                     }
                 },
                 "1009": {
@@ -26818,7 +26818,7 @@
                         "parent_location": [
                             {
                                 "end_col": 44,
-                                "end_line": 194,
+                                "end_line": 196,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
@@ -26835,7 +26835,7 @@
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 25,
-                                "start_line": 194
+                                "start_line": 196
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
@@ -26869,7 +26869,7 @@
                     "hints": [],
                     "inst": {
                         "end_col": 44,
-                        "end_line": 194,
+                        "end_line": 196,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
@@ -26910,7 +26910,7 @@
                             "While trying to update the implicit return value 'syscall_ptr' in:"
                         ],
                         "start_col": 25,
-                        "start_line": 194
+                        "start_line": 196
                     }
                 },
                 "1052": {
@@ -27279,7 +27279,7 @@
                         "parent_location": [
                             {
                                 "end_col": 44,
-                                "end_line": 194,
+                                "end_line": 196,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
@@ -27296,7 +27296,7 @@
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 25,
-                                "start_line": 194
+                                "start_line": 196
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
@@ -27330,7 +27330,7 @@
                     "hints": [],
                     "inst": {
                         "end_col": 44,
-                        "end_line": 194,
+                        "end_line": 196,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
@@ -27371,7 +27371,7 @@
                             "While trying to update the implicit return value 'syscall_ptr' in:"
                         ],
                         "start_col": 25,
-                        "start_line": 194
+                        "start_line": 196
                     }
                 },
                 "1068": {
@@ -28370,7 +28370,7 @@
                         "parent_location": [
                             {
                                 "end_col": 44,
-                                "end_line": 194,
+                                "end_line": 196,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
@@ -28387,7 +28387,7 @@
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 25,
-                                "start_line": 194
+                                "start_line": 196
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
@@ -28421,7 +28421,7 @@
                     "hints": [],
                     "inst": {
                         "end_col": 44,
-                        "end_line": 194,
+                        "end_line": 196,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
@@ -28435,7 +28435,7 @@
                                 "parent_location": [
                                     {
                                         "end_col": 46,
-                                        "end_line": 268,
+                                        "end_line": 270,
                                         "input_file": {
                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                         },
@@ -28452,7 +28452,7 @@
                                             "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                         ],
                                         "start_col": 27,
-                                        "start_line": 268
+                                        "start_line": 270
                                     },
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
@@ -28462,7 +28462,7 @@
                             "While trying to update the implicit return value 'syscall_ptr' in:"
                         ],
                         "start_col": 25,
-                        "start_line": 194
+                        "start_line": 196
                     }
                 },
                 "1105": {
@@ -28508,7 +28508,7 @@
                     "hints": [],
                     "inst": {
                         "end_col": 46,
-                        "end_line": 268,
+                        "end_line": 270,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
@@ -28549,7 +28549,7 @@
                             "While trying to update the implicit return value 'syscall_ptr' in:"
                         ],
                         "start_col": 27,
-                        "start_line": 268
+                        "start_line": 270
                     }
                 },
                 "1109": {
@@ -44657,7 +44657,7 @@
                                 "parent_location": [
                                     {
                                         "end_col": 44,
-                                        "end_line": 194,
+                                        "end_line": 196,
                                         "input_file": {
                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                         },
@@ -44674,7 +44674,7 @@
                                             "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                         ],
                                         "start_col": 25,
-                                        "start_line": 194
+                                        "start_line": 196
                                     },
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
@@ -44715,7 +44715,7 @@
                     "hints": [],
                     "inst": {
                         "end_col": 44,
-                        "end_line": 194,
+                        "end_line": 196,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
@@ -44731,18 +44731,18 @@
                                         "end_col": 30,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/event/SubmitTransaction/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                                            "filename": "autogen/starknet/event/TransactionSubmitted/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 23,
+                                                "end_col": 26,
                                                 "end_line": 29,
                                                 "input_file": {
                                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
                                                 },
                                                 "parent_location": [
                                                     {
-                                                        "end_col": 62,
+                                                        "end_col": 65,
                                                         "end_line": 430,
                                                         "input_file": {
                                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -44768,7 +44768,7 @@
                             "While trying to update the implicit return value 'syscall_ptr' in:"
                         ],
                         "start_col": 25,
-                        "start_line": 194
+                        "start_line": 196
                     }
                 },
                 "1603": {
@@ -44797,18 +44797,18 @@
                                         "end_col": 47,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/event/SubmitTransaction/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                                            "filename": "autogen/starknet/event/TransactionSubmitted/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 23,
+                                                "end_col": 26,
                                                 "end_line": 29,
                                                 "input_file": {
                                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
                                                 },
                                                 "parent_location": [
                                                     {
-                                                        "end_col": 62,
+                                                        "end_col": 65,
                                                         "end_line": 430,
                                                         "input_file": {
                                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -44853,12 +44853,12 @@
                         },
                         "parent_location": [
                             {
-                                "end_col": 41,
+                                "end_col": 44,
                                 "end_line": 430,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
                                 },
-                                "start_col": 35,
+                                "start_col": 38,
                                 "start_line": 430
                             },
                             "While expanding the reference 'caller' in:"
@@ -44883,12 +44883,12 @@
                         },
                         "parent_location": [
                             {
-                                "end_col": 54,
+                                "end_col": 57,
                                 "end_line": 430,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
                                 },
-                                "start_col": 49,
+                                "start_col": 52,
                                 "start_line": 430
                             },
                             "While expanding the reference 'nonce' in:"
@@ -44913,12 +44913,12 @@
                         },
                         "parent_location": [
                             {
-                                "end_col": 61,
+                                "end_col": 64,
                                 "end_line": 430,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
                                 },
-                                "start_col": 59,
+                                "start_col": 62,
                                 "start_line": 430
                             },
                             "While expanding the reference 'to' in:"
@@ -44936,7 +44936,7 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 62,
+                        "end_col": 65,
                         "end_line": 430,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -44957,18 +44957,18 @@
                         "end_col": 30,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/SubmitTransaction/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                            "filename": "autogen/starknet/event/TransactionSubmitted/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 23,
+                                "end_col": 26,
                                 "end_line": 29,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 62,
+                                        "end_col": 65,
                                         "end_line": 430,
                                         "input_file": {
                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -45077,18 +45077,18 @@
                         "end_col": 47,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/SubmitTransaction/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                            "filename": "autogen/starknet/event/TransactionSubmitted/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 23,
+                                "end_col": 26,
                                 "end_line": 29,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 62,
+                                        "end_col": 65,
                                         "end_line": 430,
                                         "input_file": {
                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -47149,7 +47149,7 @@
                                 "parent_location": [
                                     {
                                         "end_col": 44,
-                                        "end_line": 194,
+                                        "end_line": 196,
                                         "input_file": {
                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                         },
@@ -47166,7 +47166,7 @@
                                             "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                         ],
                                         "start_col": 25,
-                                        "start_line": 194
+                                        "start_line": 196
                                     },
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
@@ -47207,7 +47207,7 @@
                     "hints": [],
                     "inst": {
                         "end_col": 44,
-                        "end_line": 194,
+                        "end_line": 196,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
@@ -47248,7 +47248,7 @@
                             "While trying to update the implicit return value 'syscall_ptr' in:"
                         ],
                         "start_col": 25,
-                        "start_line": 194
+                        "start_line": 196
                     }
                 },
                 "1685": {
@@ -47481,18 +47481,18 @@
                                         "end_col": 30,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/event/ConfirmTransaction/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                                            "filename": "autogen/starknet/event/TransactionConfirmed/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 24,
+                                                "end_col": 26,
                                                 "end_line": 36,
                                                 "input_file": {
                                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
                                                 },
                                                 "parent_location": [
                                                     {
-                                                        "end_col": 56,
+                                                        "end_col": 58,
                                                         "end_line": 453,
                                                         "input_file": {
                                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -47547,18 +47547,18 @@
                                         "end_col": 47,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/event/ConfirmTransaction/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                                            "filename": "autogen/starknet/event/TransactionConfirmed/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 24,
+                                                "end_col": 26,
                                                 "end_line": 36,
                                                 "input_file": {
                                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
                                                 },
                                                 "parent_location": [
                                                     {
-                                                        "end_col": 56,
+                                                        "end_col": 58,
                                                         "end_line": 453,
                                                         "input_file": {
                                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -47603,12 +47603,12 @@
                         },
                         "parent_location": [
                             {
-                                "end_col": 42,
+                                "end_col": 44,
                                 "end_line": 453,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
                                 },
-                                "start_col": 36,
+                                "start_col": 38,
                                 "start_line": 453
                             },
                             "While expanding the reference 'caller' in:"
@@ -47633,12 +47633,12 @@
                         },
                         "parent_location": [
                             {
-                                "end_col": 55,
+                                "end_col": 57,
                                 "end_line": 453,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
                                 },
-                                "start_col": 50,
+                                "start_col": 52,
                                 "start_line": 453
                             },
                             "While expanding the reference 'nonce' in:"
@@ -47656,7 +47656,7 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 56,
+                        "end_col": 58,
                         "end_line": 453,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -47677,18 +47677,18 @@
                         "end_col": 30,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/ConfirmTransaction/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                            "filename": "autogen/starknet/event/TransactionConfirmed/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 26,
                                 "end_line": 36,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 56,
+                                        "end_col": 58,
                                         "end_line": 453,
                                         "input_file": {
                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -47797,18 +47797,18 @@
                         "end_col": 47,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/ConfirmTransaction/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                            "filename": "autogen/starknet/event/TransactionConfirmed/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 26,
                                 "end_line": 36,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 56,
+                                        "end_col": 58,
                                         "end_line": 453,
                                         "input_file": {
                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -49252,7 +49252,7 @@
                                 "parent_location": [
                                     {
                                         "end_col": 44,
-                                        "end_line": 194,
+                                        "end_line": 196,
                                         "input_file": {
                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                         },
@@ -49269,7 +49269,7 @@
                                             "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                         ],
                                         "start_col": 25,
-                                        "start_line": 194
+                                        "start_line": 196
                                     },
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
@@ -49310,7 +49310,7 @@
                     "hints": [],
                     "inst": {
                         "end_col": 44,
-                        "end_line": 194,
+                        "end_line": 196,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
@@ -49351,7 +49351,7 @@
                             "While trying to update the implicit return value 'syscall_ptr' in:"
                         ],
                         "start_col": 25,
-                        "start_line": 194
+                        "start_line": 196
                     }
                 },
                 "1757": {
@@ -49584,18 +49584,18 @@
                                         "end_col": 30,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/event/RevokeConfirmation/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                                            "filename": "autogen/starknet/event/ConfirmationRevoked/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 24,
+                                                "end_col": 25,
                                                 "end_line": 43,
                                                 "input_file": {
                                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
                                                 },
                                                 "parent_location": [
                                                     {
-                                                        "end_col": 56,
+                                                        "end_col": 57,
                                                         "end_line": 474,
                                                         "input_file": {
                                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -49650,18 +49650,18 @@
                                         "end_col": 47,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/event/RevokeConfirmation/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                                            "filename": "autogen/starknet/event/ConfirmationRevoked/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 24,
+                                                "end_col": 25,
                                                 "end_line": 43,
                                                 "input_file": {
                                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
                                                 },
                                                 "parent_location": [
                                                     {
-                                                        "end_col": 56,
+                                                        "end_col": 57,
                                                         "end_line": 474,
                                                         "input_file": {
                                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -49706,12 +49706,12 @@
                         },
                         "parent_location": [
                             {
-                                "end_col": 42,
+                                "end_col": 43,
                                 "end_line": 474,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
                                 },
-                                "start_col": 36,
+                                "start_col": 37,
                                 "start_line": 474
                             },
                             "While expanding the reference 'caller' in:"
@@ -49736,12 +49736,12 @@
                         },
                         "parent_location": [
                             {
-                                "end_col": 55,
+                                "end_col": 56,
                                 "end_line": 474,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
                                 },
-                                "start_col": 50,
+                                "start_col": 51,
                                 "start_line": 474
                             },
                             "While expanding the reference 'nonce' in:"
@@ -49759,7 +49759,7 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 56,
+                        "end_col": 57,
                         "end_line": 474,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -49780,18 +49780,18 @@
                         "end_col": 30,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/RevokeConfirmation/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                            "filename": "autogen/starknet/event/ConfirmationRevoked/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 25,
                                 "end_line": 43,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 56,
+                                        "end_col": 57,
                                         "end_line": 474,
                                         "input_file": {
                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -49900,18 +49900,18 @@
                         "end_col": 47,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/RevokeConfirmation/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                            "filename": "autogen/starknet/event/ConfirmationRevoked/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 25,
                                 "end_line": 43,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 56,
+                                        "end_col": 57,
                                         "end_line": 474,
                                         "input_file": {
                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -51487,7 +51487,7 @@
                                 "parent_location": [
                                     {
                                         "end_col": 44,
-                                        "end_line": 194,
+                                        "end_line": 196,
                                         "input_file": {
                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                                         },
@@ -51504,7 +51504,7 @@
                                             "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                         ],
                                         "start_col": 25,
-                                        "start_line": 194
+                                        "start_line": 196
                                     },
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
@@ -51545,7 +51545,7 @@
                     "hints": [],
                     "inst": {
                         "end_col": 44,
-                        "end_line": 194,
+                        "end_line": 196,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/.venv/lib/python3.8/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
@@ -51561,18 +51561,18 @@
                                         "end_col": 30,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/event/ExecuteTransaction/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                                            "filename": "autogen/starknet/event/TransactionExecuted/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 24,
+                                                "end_col": 25,
                                                 "end_line": 50,
                                                 "input_file": {
                                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
                                                 },
                                                 "parent_location": [
                                                     {
-                                                        "end_col": 58,
+                                                        "end_col": 59,
                                                         "end_line": 499,
                                                         "input_file": {
                                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -51598,7 +51598,7 @@
                             "While trying to update the implicit return value 'syscall_ptr' in:"
                         ],
                         "start_col": 25,
-                        "start_line": 194
+                        "start_line": 196
                     }
                 },
                 "1830": {
@@ -51627,18 +51627,18 @@
                                         "end_col": 47,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/event/ExecuteTransaction/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                                            "filename": "autogen/starknet/event/TransactionExecuted/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 24,
+                                                "end_col": 25,
                                                 "end_line": 50,
                                                 "input_file": {
                                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
                                                 },
                                                 "parent_location": [
                                                     {
-                                                        "end_col": 58,
+                                                        "end_col": 59,
                                                         "end_line": 499,
                                                         "input_file": {
                                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -51683,12 +51683,12 @@
                         },
                         "parent_location": [
                             {
-                                "end_col": 44,
+                                "end_col": 45,
                                 "end_line": 499,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
                                 },
-                                "start_col": 38,
+                                "start_col": 39,
                                 "start_line": 499
                             },
                             "While expanding the reference 'caller' in:"
@@ -51713,12 +51713,12 @@
                         },
                         "parent_location": [
                             {
-                                "end_col": 57,
+                                "end_col": 58,
                                 "end_line": 499,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
                                 },
-                                "start_col": 52,
+                                "start_col": 53,
                                 "start_line": 499
                             },
                             "While expanding the reference 'nonce' in:"
@@ -51736,7 +51736,7 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 58,
+                        "end_col": 59,
                         "end_line": 499,
                         "input_file": {
                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -51757,18 +51757,18 @@
                         "end_col": 30,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/ExecuteTransaction/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                            "filename": "autogen/starknet/event/TransactionExecuted/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 25,
                                 "end_line": 50,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 58,
+                                        "end_col": 59,
                                         "end_line": 499,
                                         "input_file": {
                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -52045,18 +52045,18 @@
                         "end_col": 47,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/event/ExecuteTransaction/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
+                            "filename": "autogen/starknet/event/TransactionExecuted/061e12d2ab61277b9c9f3e137932ed9dc55f304b27d122b3d1541234d0033a6d.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 24,
+                                "end_col": 25,
                                 "end_line": 50,
                                 "input_file": {
                                     "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 58,
+                                        "end_col": 59,
                                         "end_line": 499,
                                         "input_file": {
                                             "filename": "/home/laurip/src/eqlabs/starknet-multisig/contracts/contracts/Multisig.cairo"
@@ -64001,44 +64001,44 @@
             ]
         },
         "identifiers": {
-            "__main__.ConfirmTransaction": {
+            "__main__.ConfirmationRevoked": {
                 "type": "namespace"
             },
-            "__main__.ConfirmTransaction.Args": {
-                "full_name": "__main__.ConfirmTransaction.Args",
+            "__main__.ConfirmationRevoked.Args": {
+                "full_name": "__main__.ConfirmationRevoked.Args",
                 "members": {},
                 "size": 0,
                 "type": "struct"
             },
-            "__main__.ConfirmTransaction.ImplicitArgs": {
-                "full_name": "__main__.ConfirmTransaction.ImplicitArgs",
+            "__main__.ConfirmationRevoked.ImplicitArgs": {
+                "full_name": "__main__.ConfirmationRevoked.ImplicitArgs",
                 "members": {},
                 "size": 0,
                 "type": "struct"
             },
-            "__main__.ConfirmTransaction.Return": {
+            "__main__.ConfirmationRevoked.Return": {
                 "cairo_type": "()",
                 "type": "type_definition"
             },
-            "__main__.ConfirmTransaction.SELECTOR": {
+            "__main__.ConfirmationRevoked.SELECTOR": {
                 "type": "const",
-                "value": 1140933478279648168984347876706281227855182548398597364416959125748140490144
+                "value": 399774321108028850593279613278148976653730968258519628046133670053989889083
             },
-            "__main__.ConfirmTransaction.SIZEOF_LOCALS": {
+            "__main__.ConfirmationRevoked.SIZEOF_LOCALS": {
                 "type": "const",
                 "value": 0
             },
-            "__main__.ConfirmTransaction.alloc": {
+            "__main__.ConfirmationRevoked.alloc": {
                 "destination": "starkware.cairo.common.alloc.alloc",
                 "type": "alias"
             },
-            "__main__.ConfirmTransaction.emit": {
+            "__main__.ConfirmationRevoked.emit": {
                 "decorators": [],
-                "pc": 532,
+                "pc": 557,
                 "type": "function"
             },
-            "__main__.ConfirmTransaction.emit.Args": {
-                "full_name": "__main__.ConfirmTransaction.emit.Args",
+            "__main__.ConfirmationRevoked.emit.Args": {
+                "full_name": "__main__.ConfirmationRevoked.emit.Args",
                 "members": {
                     "nonce": {
                         "cairo_type": "felt",
@@ -64052,8 +64052,8 @@
                 "size": 2,
                 "type": "struct"
             },
-            "__main__.ConfirmTransaction.emit.ImplicitArgs": {
-                "full_name": "__main__.ConfirmTransaction.emit.ImplicitArgs",
+            "__main__.ConfirmationRevoked.emit.ImplicitArgs": {
+                "full_name": "__main__.ConfirmationRevoked.emit.ImplicitArgs",
                 "members": {
                     "range_check_ptr": {
                         "cairo_type": "felt",
@@ -64067,101 +64067,19 @@
                 "size": 2,
                 "type": "struct"
             },
-            "__main__.ConfirmTransaction.emit.Return": {
+            "__main__.ConfirmationRevoked.emit.Return": {
                 "cairo_type": "()",
                 "type": "type_definition"
             },
-            "__main__.ConfirmTransaction.emit.SIZEOF_LOCALS": {
+            "__main__.ConfirmationRevoked.emit.SIZEOF_LOCALS": {
                 "type": "const",
                 "value": 2
             },
-            "__main__.ConfirmTransaction.emit_event": {
+            "__main__.ConfirmationRevoked.emit_event": {
                 "destination": "starkware.starknet.common.syscalls.emit_event",
                 "type": "alias"
             },
-            "__main__.ConfirmTransaction.memcpy": {
-                "destination": "starkware.cairo.common.memcpy.memcpy",
-                "type": "alias"
-            },
-            "__main__.ExecuteTransaction": {
-                "type": "namespace"
-            },
-            "__main__.ExecuteTransaction.Args": {
-                "full_name": "__main__.ExecuteTransaction.Args",
-                "members": {},
-                "size": 0,
-                "type": "struct"
-            },
-            "__main__.ExecuteTransaction.ImplicitArgs": {
-                "full_name": "__main__.ExecuteTransaction.ImplicitArgs",
-                "members": {},
-                "size": 0,
-                "type": "struct"
-            },
-            "__main__.ExecuteTransaction.Return": {
-                "cairo_type": "()",
-                "type": "type_definition"
-            },
-            "__main__.ExecuteTransaction.SELECTOR": {
-                "type": "const",
-                "value": 1485253047429662869218618931063463937434935309475449059845236166454870327114
-            },
-            "__main__.ExecuteTransaction.SIZEOF_LOCALS": {
-                "type": "const",
-                "value": 0
-            },
-            "__main__.ExecuteTransaction.alloc": {
-                "destination": "starkware.cairo.common.alloc.alloc",
-                "type": "alias"
-            },
-            "__main__.ExecuteTransaction.emit": {
-                "decorators": [],
-                "pc": 582,
-                "type": "function"
-            },
-            "__main__.ExecuteTransaction.emit.Args": {
-                "full_name": "__main__.ExecuteTransaction.emit.Args",
-                "members": {
-                    "executer": {
-                        "cairo_type": "felt",
-                        "offset": 0
-                    },
-                    "nonce": {
-                        "cairo_type": "felt",
-                        "offset": 1
-                    }
-                },
-                "size": 2,
-                "type": "struct"
-            },
-            "__main__.ExecuteTransaction.emit.ImplicitArgs": {
-                "full_name": "__main__.ExecuteTransaction.emit.ImplicitArgs",
-                "members": {
-                    "range_check_ptr": {
-                        "cairo_type": "felt",
-                        "offset": 1
-                    },
-                    "syscall_ptr": {
-                        "cairo_type": "felt*",
-                        "offset": 0
-                    }
-                },
-                "size": 2,
-                "type": "struct"
-            },
-            "__main__.ExecuteTransaction.emit.Return": {
-                "cairo_type": "()",
-                "type": "type_definition"
-            },
-            "__main__.ExecuteTransaction.emit.SIZEOF_LOCALS": {
-                "type": "const",
-                "value": 2
-            },
-            "__main__.ExecuteTransaction.emit_event": {
-                "destination": "starkware.starknet.common.syscalls.emit_event",
-                "type": "alias"
-            },
-            "__main__.ExecuteTransaction.memcpy": {
+            "__main__.ConfirmationRevoked.memcpy": {
                 "destination": "starkware.cairo.common.memcpy.memcpy",
                 "type": "alias"
             },
@@ -64171,88 +64089,6 @@
             },
             "__main__.HashBuiltin": {
                 "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
-                "type": "alias"
-            },
-            "__main__.RevokeConfirmation": {
-                "type": "namespace"
-            },
-            "__main__.RevokeConfirmation.Args": {
-                "full_name": "__main__.RevokeConfirmation.Args",
-                "members": {},
-                "size": 0,
-                "type": "struct"
-            },
-            "__main__.RevokeConfirmation.ImplicitArgs": {
-                "full_name": "__main__.RevokeConfirmation.ImplicitArgs",
-                "members": {},
-                "size": 0,
-                "type": "struct"
-            },
-            "__main__.RevokeConfirmation.Return": {
-                "cairo_type": "()",
-                "type": "type_definition"
-            },
-            "__main__.RevokeConfirmation.SELECTOR": {
-                "type": "const",
-                "value": 1118274257330409905261614104604431887452286335770351779641886024959029778203
-            },
-            "__main__.RevokeConfirmation.SIZEOF_LOCALS": {
-                "type": "const",
-                "value": 0
-            },
-            "__main__.RevokeConfirmation.alloc": {
-                "destination": "starkware.cairo.common.alloc.alloc",
-                "type": "alias"
-            },
-            "__main__.RevokeConfirmation.emit": {
-                "decorators": [],
-                "pc": 557,
-                "type": "function"
-            },
-            "__main__.RevokeConfirmation.emit.Args": {
-                "full_name": "__main__.RevokeConfirmation.emit.Args",
-                "members": {
-                    "nonce": {
-                        "cairo_type": "felt",
-                        "offset": 1
-                    },
-                    "signer": {
-                        "cairo_type": "felt",
-                        "offset": 0
-                    }
-                },
-                "size": 2,
-                "type": "struct"
-            },
-            "__main__.RevokeConfirmation.emit.ImplicitArgs": {
-                "full_name": "__main__.RevokeConfirmation.emit.ImplicitArgs",
-                "members": {
-                    "range_check_ptr": {
-                        "cairo_type": "felt",
-                        "offset": 1
-                    },
-                    "syscall_ptr": {
-                        "cairo_type": "felt*",
-                        "offset": 0
-                    }
-                },
-                "size": 2,
-                "type": "struct"
-            },
-            "__main__.RevokeConfirmation.emit.Return": {
-                "cairo_type": "()",
-                "type": "type_definition"
-            },
-            "__main__.RevokeConfirmation.emit.SIZEOF_LOCALS": {
-                "type": "const",
-                "value": 2
-            },
-            "__main__.RevokeConfirmation.emit_event": {
-                "destination": "starkware.starknet.common.syscalls.emit_event",
-                "type": "alias"
-            },
-            "__main__.RevokeConfirmation.memcpy": {
-                "destination": "starkware.cairo.common.memcpy.memcpy",
                 "type": "alias"
             },
             "__main__.SignersSet": {
@@ -64334,92 +64170,6 @@
                 "type": "alias"
             },
             "__main__.SignersSet.memcpy": {
-                "destination": "starkware.cairo.common.memcpy.memcpy",
-                "type": "alias"
-            },
-            "__main__.SubmitTransaction": {
-                "type": "namespace"
-            },
-            "__main__.SubmitTransaction.Args": {
-                "full_name": "__main__.SubmitTransaction.Args",
-                "members": {},
-                "size": 0,
-                "type": "struct"
-            },
-            "__main__.SubmitTransaction.ImplicitArgs": {
-                "full_name": "__main__.SubmitTransaction.ImplicitArgs",
-                "members": {},
-                "size": 0,
-                "type": "struct"
-            },
-            "__main__.SubmitTransaction.Return": {
-                "cairo_type": "()",
-                "type": "type_definition"
-            },
-            "__main__.SubmitTransaction.SELECTOR": {
-                "type": "const",
-                "value": 929216044698956821292610355061363398581956176188459551471824977192779301551
-            },
-            "__main__.SubmitTransaction.SIZEOF_LOCALS": {
-                "type": "const",
-                "value": 0
-            },
-            "__main__.SubmitTransaction.alloc": {
-                "destination": "starkware.cairo.common.alloc.alloc",
-                "type": "alias"
-            },
-            "__main__.SubmitTransaction.emit": {
-                "decorators": [],
-                "pc": 506,
-                "type": "function"
-            },
-            "__main__.SubmitTransaction.emit.Args": {
-                "full_name": "__main__.SubmitTransaction.emit.Args",
-                "members": {
-                    "nonce": {
-                        "cairo_type": "felt",
-                        "offset": 1
-                    },
-                    "signer": {
-                        "cairo_type": "felt",
-                        "offset": 0
-                    },
-                    "to": {
-                        "cairo_type": "felt",
-                        "offset": 2
-                    }
-                },
-                "size": 3,
-                "type": "struct"
-            },
-            "__main__.SubmitTransaction.emit.ImplicitArgs": {
-                "full_name": "__main__.SubmitTransaction.emit.ImplicitArgs",
-                "members": {
-                    "range_check_ptr": {
-                        "cairo_type": "felt",
-                        "offset": 1
-                    },
-                    "syscall_ptr": {
-                        "cairo_type": "felt*",
-                        "offset": 0
-                    }
-                },
-                "size": 2,
-                "type": "struct"
-            },
-            "__main__.SubmitTransaction.emit.Return": {
-                "cairo_type": "()",
-                "type": "type_definition"
-            },
-            "__main__.SubmitTransaction.emit.SIZEOF_LOCALS": {
-                "type": "const",
-                "value": 2
-            },
-            "__main__.SubmitTransaction.emit_event": {
-                "destination": "starkware.starknet.common.syscalls.emit_event",
-                "type": "alias"
-            },
-            "__main__.SubmitTransaction.memcpy": {
                 "destination": "starkware.cairo.common.memcpy.memcpy",
                 "type": "alias"
             },
@@ -64531,6 +64281,256 @@
                 },
                 "size": 5,
                 "type": "struct"
+            },
+            "__main__.TransactionConfirmed": {
+                "type": "namespace"
+            },
+            "__main__.TransactionConfirmed.Args": {
+                "full_name": "__main__.TransactionConfirmed.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__main__.TransactionConfirmed.ImplicitArgs": {
+                "full_name": "__main__.TransactionConfirmed.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__main__.TransactionConfirmed.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "__main__.TransactionConfirmed.SELECTOR": {
+                "type": "const",
+                "value": 131425480171470489600231791378472292480259385557796368323212843128885728653
+            },
+            "__main__.TransactionConfirmed.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.TransactionConfirmed.alloc": {
+                "destination": "starkware.cairo.common.alloc.alloc",
+                "type": "alias"
+            },
+            "__main__.TransactionConfirmed.emit": {
+                "decorators": [],
+                "pc": 532,
+                "type": "function"
+            },
+            "__main__.TransactionConfirmed.emit.Args": {
+                "full_name": "__main__.TransactionConfirmed.emit.Args",
+                "members": {
+                    "nonce": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    },
+                    "signer": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "__main__.TransactionConfirmed.emit.ImplicitArgs": {
+                "full_name": "__main__.TransactionConfirmed.emit.ImplicitArgs",
+                "members": {
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    },
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "__main__.TransactionConfirmed.emit.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "__main__.TransactionConfirmed.emit.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 2
+            },
+            "__main__.TransactionConfirmed.emit_event": {
+                "destination": "starkware.starknet.common.syscalls.emit_event",
+                "type": "alias"
+            },
+            "__main__.TransactionConfirmed.memcpy": {
+                "destination": "starkware.cairo.common.memcpy.memcpy",
+                "type": "alias"
+            },
+            "__main__.TransactionExecuted": {
+                "type": "namespace"
+            },
+            "__main__.TransactionExecuted.Args": {
+                "full_name": "__main__.TransactionExecuted.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__main__.TransactionExecuted.ImplicitArgs": {
+                "full_name": "__main__.TransactionExecuted.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__main__.TransactionExecuted.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "__main__.TransactionExecuted.SELECTOR": {
+                "type": "const",
+                "value": 842551570264321250259211319413208572753709361197310322568628222471998423985
+            },
+            "__main__.TransactionExecuted.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.TransactionExecuted.alloc": {
+                "destination": "starkware.cairo.common.alloc.alloc",
+                "type": "alias"
+            },
+            "__main__.TransactionExecuted.emit": {
+                "decorators": [],
+                "pc": 582,
+                "type": "function"
+            },
+            "__main__.TransactionExecuted.emit.Args": {
+                "full_name": "__main__.TransactionExecuted.emit.Args",
+                "members": {
+                    "executer": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    },
+                    "nonce": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "__main__.TransactionExecuted.emit.ImplicitArgs": {
+                "full_name": "__main__.TransactionExecuted.emit.ImplicitArgs",
+                "members": {
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    },
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "__main__.TransactionExecuted.emit.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "__main__.TransactionExecuted.emit.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 2
+            },
+            "__main__.TransactionExecuted.emit_event": {
+                "destination": "starkware.starknet.common.syscalls.emit_event",
+                "type": "alias"
+            },
+            "__main__.TransactionExecuted.memcpy": {
+                "destination": "starkware.cairo.common.memcpy.memcpy",
+                "type": "alias"
+            },
+            "__main__.TransactionSubmitted": {
+                "type": "namespace"
+            },
+            "__main__.TransactionSubmitted.Args": {
+                "full_name": "__main__.TransactionSubmitted.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__main__.TransactionSubmitted.ImplicitArgs": {
+                "full_name": "__main__.TransactionSubmitted.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__main__.TransactionSubmitted.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "__main__.TransactionSubmitted.SELECTOR": {
+                "type": "const",
+                "value": 1594388778992650636039369743054192841957568948414458307496380030157148024657
+            },
+            "__main__.TransactionSubmitted.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.TransactionSubmitted.alloc": {
+                "destination": "starkware.cairo.common.alloc.alloc",
+                "type": "alias"
+            },
+            "__main__.TransactionSubmitted.emit": {
+                "decorators": [],
+                "pc": 506,
+                "type": "function"
+            },
+            "__main__.TransactionSubmitted.emit.Args": {
+                "full_name": "__main__.TransactionSubmitted.emit.Args",
+                "members": {
+                    "nonce": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    },
+                    "signer": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    },
+                    "to": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "__main__.TransactionSubmitted.emit.ImplicitArgs": {
+                "full_name": "__main__.TransactionSubmitted.emit.ImplicitArgs",
+                "members": {
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    },
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "__main__.TransactionSubmitted.emit.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "__main__.TransactionSubmitted.emit.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 2
+            },
+            "__main__.TransactionSubmitted.emit_event": {
+                "destination": "starkware.starknet.common.syscalls.emit_event",
+                "type": "alias"
+            },
+            "__main__.TransactionSubmitted.memcpy": {
+                "destination": "starkware.cairo.common.memcpy.memcpy",
+                "type": "alias"
             },
             "__main__._clean_signers_range": {
                 "decorators": [],
@@ -70393,7 +70393,7 @@
                         "cairo_type": "felt",
                         "offset": 2
                     },
-                    "reserved": {
+                    "deploy_from_zero": {
                         "cairo_type": "felt",
                         "offset": 5
                     },


### PR DESCRIPTION
Change events to be named the same way.
Disable devnet restart until a devnet issue is fixed