### PR TITLE
Optimize for new devnet version

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -37,7 +37,7 @@ After that, inside the virtual environment:
 - Run the devnet: `npm run local`
 - Open another venv tab and run the unit tests with `npx hardhat test`
 
-Tested to be working at least with devnet version 0.2.6.
+Tested to be working at least with devnet version 0.2.10.
 
 ## Acknowledgements
 

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.5",
-    "@shardlabs/starknet-hardhat-plugin": "0.6.2",
+    "@shardlabs/starknet-hardhat-plugin": "0.6.3",
     "@toruslabs/starkware-crypto": "^1.0.0",
     "@types/chai": "^4.2.22",
     "@types/elliptic": "^6.4.14",

--- a/contracts/test/Multisig.test.ts
+++ b/contracts/test/Multisig.test.ts
@@ -32,7 +32,7 @@ describe("Multisig with single signer", function () {
   let accountAddress: string;
 
   before(async function () {
-    //starknet.devnet.restart(); // disabled until https://github.com/Shard-Labs/starknet-devnet/issues/221 is fixed
+    starknet.devnet.restart();
 
     account = await starknet.deployAccount("OpenZeppelin");
     nonSigner = await starknet.deployAccount("OpenZeppelin");
@@ -55,7 +55,6 @@ describe("Multisig with single signer", function () {
     );
 
     await starknet.devnet.dump(dumpFile);
-    await new Promise((f) => setTimeout(f, 1000)); // to allow the dump to complete
   });
 
   beforeEach(async function () {
@@ -1162,7 +1161,7 @@ describe("Multisig with multiple signers", function () {
   let account3: Account;
 
   before(async function () {
-    //starknet.devnet.restart(); // disabled until https://github.com/Shard-Labs/starknet-devnet/issues/221 is fixed
+    starknet.devnet.restart();
 
     account1 = await starknet.deployAccount("OpenZeppelin");
     account2 = await starknet.deployAccount("OpenZeppelin");
@@ -1187,7 +1186,6 @@ describe("Multisig with multiple signers", function () {
     console.log("Account3: " + account3.starknetContract.address);
 
     await starknet.devnet.dump(dumpFile);
-    await new Promise((f) => setTimeout(f, 1000)); // to allow the dump to complete
   });
 
   beforeEach(async function () {

--- a/contracts/yarn.lock
+++ b/contracts/yarn.lock
@@ -562,10 +562,10 @@
     "@sentry/types" "5.30.0"
     tslib "^1.9.3"
 
-"@shardlabs/starknet-hardhat-plugin@0.6.2":
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/@shardlabs/starknet-hardhat-plugin/-/starknet-hardhat-plugin-0.6.2.tgz#63b183b7a44074b116a0ab5a2f56a8e85d31b427"
-  integrity sha512-TGfAa2koy1Yhlpi5ENufcZqT4OVHL4hVKMnAcCcE/h4fIJGTdj5kIqJX1PT4ZZ5hyr//EwyqkiQqReEjEpzyVw==
+"@shardlabs/starknet-hardhat-plugin@0.6.3":
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/@shardlabs/starknet-hardhat-plugin/-/starknet-hardhat-plugin-0.6.3.tgz#1fea5672a4b4d58943b56631e0271399c1a5225f"
+  integrity sha512-c8utit5fvJbzY2e8qym7L9gWlMCLrmdLhZoLkmPA5NsExXSuIJZEWmQe6DsLv/yWLjyMAfb2ny3uGZ8cjGAcbQ==
   dependencies:
     "@nomiclabs/hardhat-docker" "^2.0.2"
     axios "^0.24.0"


### PR DESCRIPTION
New devnet version was released.

- Re-enable devnet restart in unit tests
- Remove superfluous dump delays
- Update hardhat at the same time. Running all unit tests in venv went down from 10mins to 3 mins!